### PR TITLE
Modernize sdk-tester: fix builds across all SDKs and make the suite runnable again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 data.json
+.build-ctx/
 
 data_node/*.tgz
 data_node/node_modules
@@ -14,3 +15,5 @@ data_ruby/Gemfile.lock
 **/*.log
 **/*.pyc
 tests/__pycache__/*
+
+env

--- a/README.md
+++ b/README.md
@@ -1,421 +1,381 @@
-# About
+# sdk-tester
 
-This project aims to allow making an API request using any of our
-supported OpenAPI SDKs.
+Language-agnostic harness that exercises the Dropbox Sign OpenAPI SDKs. Each
+supported SDK lives inside a dedicated Docker image; the `./run` script feeds
+a normalised JSON payload to the image and returns a normalised JSON response,
+which makes it easy to drive the same scenario through every SDK from a single
+test suite.
 
-# Demo
+Supported SDKs: `dotnet`, `java`, `node`, `php`, `python`, `ruby` (`csharp` is
+accepted as an alias for `dotnet`).
 
-See [./demo](./demo) for a demo
-on how this project may be used in our testing suite.
+See [`./demo`](./demo) for an example of how to embed the harness in your own
+test code.
 
-# How to Use
+## Prerequisites
 
-## Generate Container Images
+- Docker (Docker Desktop, Colima, OrbStack, etc.) running locally.
+- Bash (any version — the scripts no longer rely on Bash 4-only syntax).
+- Python 3 with `pytest` + `requests`, if you want to run the pytest suite:
+  ```bash
+  pip3 install pytest requests
+  ```
 
-Each SDK will have its own container image. You can build all containers in one
-go by running:
+## Building the SDK containers
+
+`./build` produces one Docker image per SDK (`dropbox/sign-<sdk>:latest`).
+
+```text
+./build [options] SDK
+```
+
+Options:
+
+| Flag | Meaning |
+|---|---|
+| `--sdk-ref REF` | Git ref (branch/tag/commit) for SDKs sourced from git (`python`, `ruby`, `node`, `dotnet`). For `java` this is the Maven Central version. For `php` it is the Composer version constraint. |
+| `--local PATH` | Build against a local SDK source directory instead of fetching it from git / a package registry. Mutually exclusive with `all`. |
+| `--help` | Show help and exit. |
+
+`SDK` is one of `dotnet java node php python ruby` or `all` (or `csharp` as an
+alias for `dotnet`). Examples:
 
 ```bash
-./build all
+./build all                          # build every SDK from defaults
+./build python                       # build just python
+./build --sdk-ref=v1.4.0 node        # pin node to a specific upstream ref
+./build --sdk-ref=2.5.0  java        # pin java to a specific Maven version
+./build --local ../dropbox-sign-python python   # build against a local SDK
 ```
 
-or build each individually by passing the SDK as parameter:
+### Where each SDK comes from
 
-```bash
-# dotnet
-./build dotnet
-# java
-./build java
-# Node
-./build node
-# PHP
-./build php
-# Python
-./build python
-# Ruby
-./build ruby
+| SDK | Default source | Definition file |
+|---|---|---|
+| python | `github.com/hellosign/dropbox-sign-python @ main` | `data_python/requirements.txt` |
+| ruby | `github.com/hellosign/dropbox-sign-ruby @ main` | `data_ruby/Gemfile` |
+| node | `github:hellosign/dropbox-sign-node#main` | `data_node/package.json` |
+| dotnet | `github.com/hellosign/dropbox-sign-dotnet @ main` (cloned inside the image) | `data_dotnet/Dockerfile` |
+| php | Packagist `dropbox/sign ^1.0.0` | `data_php/composer.json` |
+| java | Maven Central `com.dropbox.sign:dropbox-sign:2.5.0` | `data_java/pom.xml` |
+
+`--sdk-ref` rewrites the relevant descriptor in a staged build context (under
+`.build-ctx/<sdk>/`, git-ignored) so the originals in `data_<sdk>/` are never
+touched. `--local` does the same plus copies your local SDK into the context
+at `./sdk-src/` and rewrites the descriptor to reference `/sdk-src` inside the
+container (for Java it `mvn install`s the local SDK into the image-local Maven
+repo and pins the tester's `pom.xml` to the version in the local `pom.xml`).
+
+### How `./build` runs the SDK
+
+`./build` always runs with `--no-cache`. If your local SDK tree has a large
+`node_modules/`, `vendor/`, `target/`, `build/`, `dist/`, `bin/`, `obj/`,
+`venv/`, `.venv/`, `__pycache__/`, or `*.egg-info/` folder, it is excluded from
+the copy so the build context stays small.
+
+## Running a single request with `./run`
+
+```text
+./run [options]
 ```
 
-## Run Tool
-
-You run any container using the `./run` script and passing the SDK as parameter:
-
-```bash
-$ ./run php
-
-Uses the selected Dropbox Sign SDK to make a request to the Dropbox Sign API
---sdk             one of "dotnet", "java", "node", "php", "python", "ruby"
-                    (required)
---auth_type       one of "apikey", "oauth"
-                    (required)
---auth_key        auth key
-                    If --auth_type=apikey, pass API Key
-                    If --auth_type=oauth, pass OAuth Bearer Token
-                    (required)
---json            valid JSON file containing all request data
-                    OR base64-encoded JSON string
-                    (required)
---server          API server to use, must be like "api.hellosign.com".
-                    (defaults to api.hellosign.com)
---uploads_dir     directory where files that can be uploaded to the API live.
-                    (defaults to /Users/jtreminio/www/hellosign/openapi/sdk-tester/file_uploads)
---dev_mode        run container in dev mode
-                    (optional, default false)
---help            display this help and exit
-```
-
-The command to run each script is identical to each other, and they all require
-the same flags to function correctly.
-
-## Run test using Pytest
-install pytest using below command
-```bash
-pip3 install pytest
-```
-To run all the tests under the tests/ folder
-```bash
- pytest -svra  tests/ 
-```
-
-To run individual tests from a file. 
-```bash
-pytest -svra tests/test_signature_request.py::test_signature_request_send
-```
-
-To run tests in individual environment in QA env 
-To run on staging pass SERVER = api.staging-hellosign.com and appropriate API_KEY
-```bash
-LANGUAGE=python API_KEY=<API_KEY>  SERVER=api.qa-hellosign.com  pytest -svra tests/test_template.py::test_get_template
-```
-
-# Flags
-
-## `--sdk` SDK (required)
-
-One of `dotnet`, `java`, `node`, `php`, `python`, `ruby`.
-
-## `--auth_type` Auth Type (required)
-
-Currently we support API key `apikey` or OAuth bearer token `oauth`
-
-## `--auth_key` Auth Key (required)
-
-If auth type (`--auth_type`) is `apikey` this will be the API Key.
-
-If auth type (`--auth_type`) is `oauth` this will be the OAuth bearer token.
-
-## `--json` JSON Payload (required)
-
-A local file containing the JSON data sent in the request to the API, OR
-a base64-encoded string containing the JSON data sent in the request to the API.
-
-See the [JSON Data](#json-data) section for more information.
-
-## `--server` Server (optional)
-
-What server to make the API request to. For example, `api.hellosign.com`.
-
-## `--uploads_dir` Uploads Directory (optional)
-
-Local directory containing any files you would want to upload in the API request.
-
-Defaults to [./file_uploads](./file_uploads).
-
-## `--dev_mode` Dev Mode
-
-Runs the container in dev mode. Simply calling `--dev_mode` enabled Dev mode,
-there is  no need to pass a value to it. It is disabled by default.
-
-Dev mode adds a cookie `XDEBUG_SESSION=xdebug` to the request that allows
-debugging the API backend.
-
-It also loads the local `requester.*` file into the container, overwriting the
-file that was baked into the image during the build step.
-
-Dev mode is extremely useful when you want to debug the request via the API
-backend, or want to make changes to the `requester.*` file locally and test them
-out without needing to rebuild the container image.
-
-Using Dev mode you can also change request data (sent to the API) by editing the
-[data.json](./data.json) file that is generated after running a build script.
-Changes to this file are ignored by git.
-
-# JSON Data
-
-Whether using a local file or a base64-encoded string for the JSON payload
-it must match the following shape:
-
-```
-{
-    "operationId": <string> (required),
-    "data": <object>,
-    "parameters": <object>,
-    "files": <object>
-}
-```
-
-## `operationId` (Required)
-
-This is a string that must match one of the `operationId` values within the
-[OpenAPI spec's `paths` object](https://github.com/hellosign/hellosign-openapi/blob/oas-release/openapi.yaml).
-
-In the example below, the `operationId` value is `accountCreate`:
-
-```yaml
-paths:
-  /account/create:
-    post:
-      tags:
-        - Account
-      summary: 'Create Account'
-      description: 'Creates a new Dropbox Sign Account that is associated with the specified `email_address`.'
-      operationId: accountCreate
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AccountCreateRequest'
-            examples:
-              default_example:
-                $ref: '#/components/examples/AccountCreateRequestDefaultExample'
-              oauth:
-                $ref: '#/components/examples/AccountCreateRequestOAuthExample'
-```
-
-## `data`
-
-The data to be sent to the API in the body of the request. Must be an object.
-
-## `parameters`
-
-If the API endpoint you want to use has query parameters, you must define them here.
-
-For example, `GET /account` has a `account_id` query parameter.
-
-## `files`
-
-If the API endpoint you want to use allows uploading files, you must define them here.
-
-The file you want to use _must_ be found in the [`file_uploads`](./file_uploads) directory!
-
-If the endpoint supports multiple files you must pass a nested object.
-
-## JSON Examples
-
-### `accountGet` (with parameters)
-
-```json
-{
-  "operationId": "accountGet",
-  "parameters": {
-    "account_id": "5d38f3a287c072a2ac741191c5c055936a56b933"
-  },
-  "data": {},
-  "files": {}
-}
-```
-
-### `apiAppCreate` (single file upload)
-
-```json
-{
-  "operationId": "apiAppCreate",
-  "parameters": {},
-  "data": {
-    "name": "My Production App",
-    "callback_url": "https://example.com/callback",
-    "domains": [
-      "example.com"
-    ],
-    "oauth": {
-      "callback_url": "https://example.com/oauth",
-      "scopes": [
-        "basic_account_info",
-        "request_signature"
-      ]
-    },
-    "options": {
-      "can_insert_everywhere": true
-    },
-    "white_labeling_options": {
-      "header_background_color": "#1A1A1A",
-      "legal_version": "terms1",
-      "link_color": "#00B3E6",
-      "page_background_color": "#F7F8F9",
-      "primary_button_color": "#00b3e6",
-      "primary_button_color_hover": "#00B3E6",
-      "primary_button_text_color": "#ffffff",
-      "primary_button_text_color_hover": "#FFFFFF",
-      "secondary_button_color": "#FFFFFF",
-      "secondary_button_color_hover": "#FFFFFF",
-      "secondary_button_text_color": "#00B3E6",
-      "secondary_button_text_color_hover": "#00B3E6",
-      "text_color1": "#808080",
-      "text_color2": "#FFFFFF"
-    }
-  },
-  "files": {
-    "custom_logo_file": "pdf-sample.pdf"
-  }
-}
-```
-
-### `signatureRequestSend` (multiple file uploads)
-
-```json
-{
-  "operationId": "signatureRequestSend",
-  "parameters": {},
-  "data": {
-    "cc_email_addresses": [
-      "lawyer@hellosign.com",
-      "lawyer@example.com"
-    ],
-    "message": "Please sign this NDA and then we can discuss more. Let me know if you\nhave any questions.",
-    "signers": [
-      {
-        "email_address": "s1@example.com",
-        "name": "Signer 1",
-        "order": 0,
-        "sms_phone_number": "+14155550100",
-        "sms_phone_number_type": "delivery"
-      }
-    ],
-    "subject": "The NDA we talked about",
-    "test_mode": true,
-    "title": "NDA with Acme Co."
-  },
-  "files": {
-    "files": [
-      "pdf-sample.pdf",
-      "pdf-sample-2.pdf"
-    ]
-  }
-}
-```
-
-# Response Examples
-
-All responses will match the following shape, whether the response was
-successful or resulted in an error:
-
-```
-{
-    "body": <object>,
-    "status_code": <integer>,
-    "headers": <object>
-}
-```
-
-## Response Success Example
-
-This is an example of a _successful_ API response:
-
-```json
-{
-    "body": {
-        "account": {
-            "account_id": "0f7cfef800c571173e5fec744bce8b27c3f30569",
-            "email_address": "signer2@hellosign.com",
-            "is_locked": false,
-            "is_paid_hs": false,
-            "is_paid_hf": false,
-            "quotas": {
-                "api_signature_requests_left": 0,
-                "documents_left": 3,
-                "templates_left": 0
-            },
-            "locale": "en-US"
-        }
-    },
-    "status_code": 200,
-    "headers": {
-        "date": "Tue, 26 Jul 2022 15:16:17 GMT",
-        "server": "Apache",
-        "x-powered-by": "PHP\/7.4.28",
-        "x-robots-tag": "noindex",
-        "x-ratelimit-limit": "10000",
-        "x-ratelimit-limit-remaining": "9999",
-        "x-ratelimit-reset": "1658848577",
-        "access-control-allow-origin": "*",
-        "access-control-allow-headers": "Authorization, Origin, X-Requested-With, Content-Type, Accept",
-        "access-control-allow-methods": "GET, POST, OPTIONS",
-        "user-agent": "Dropbox Sign API",
-        "vary": "Accept-Encoding",
-        "strict-transport-security": "max-age=15768000",
-        "p3p": "CP=\"NOP3PPOLICY\"",
-        "content-length": "360",
-        "connection": "close",
-        "content-type": "application\/json"
-    }
-}
-```
-
-Note that header names are all lowercased!
-
-## Response Error Example
-
-This is an example of a _unsuccessful_ API response:
-
-```json
-{
-    "body": {
-        "error": {
-            "error_msg": "Unauthorized api key",
-            "error_name": "unauthorized"
-        }
-    },
-    "status_code": 401,
-    "headers": {
-        "date": "Tue, 26 Jul 2022 15:23:38 GMT",
-        "content-type": "application\/json",
-        "content-length": "74",
-        "connection": "keep-alive",
-        "server": "Apache",
-        "strict-transport-security": "max-age=31536000",
-        "vary": "Origin",
-        "x-robots-tag": "noindex",
-        "access-control-allow-origin": "*",
-        "access-control-allow-headers": "Authorization, Origin, X-Requested-With, Content-Type, Accept, Request-URL, Referrer-Policy, Referer, Sec-CH-UA, Sec-CH-UA-Mobile, Sec-CH-UA-Platform, Sec-Fetch-Site, User-Agent, X-User-Agent",
-        "access-control-allow-methods": "GET, POST, OPTIONS, PUT, DELETE",
-        "user_agent": "Dropbox Sign API",
-        "p3p": "CP=\"NOP3PPOLICY\""
-    }
-}
-```
-
-Note that header names are all lowercased!
-
-# Run Examples
-
-The following are some examples with all required flags.
-
-## Example Using Local JSON File
+| Flag | Required | Description |
+|---|---|---|
+| `--sdk=<sdk>` | yes | `dotnet`, `java`, `node`, `php`, `python`, `ruby` (or `csharp`). |
+| `--auth_type=<type>` | yes | `apikey` or `oauth`. |
+| `--auth_key=<value>` | yes | API key (for `apikey`) or OAuth bearer token (for `oauth`). |
+| `--json=<path or b64>` | yes | Either a path to a JSON file or a base64-encoded JSON string. |
+| `--server=<host>` | no | API host (no scheme). Defaults to `api.hellosign.com`. |
+| `--uploads_dir=<path>` | no | Directory mounted at `/file_uploads`. Defaults to `./file_uploads`. |
+| `--dev_mode` | no | Mount the local `data_<sdk>/requester.*` over the one baked into the image (see note below). |
+| `--help` | no | Show help and exit. |
+
+`./run` mounts `--uploads_dir` at `/file_uploads` in the container; any file
+names used under `files` in your JSON payload must live in that directory.
+
+### Run examples
+
+Using a JSON file:
 
 ```bash
 ./run \
     --sdk=php \
     --auth_type=apikey \
-    --auth_key=4e0a8a8bd9fea228a1de515a43a75ded2e495471b830069cc8e1821c13c31ce4 \
-    --json="${PWD}/test_fixtures/accountCreate-example_01.json"
+    --auth_key=$HS_API_KEY \
+    --json="${PWD}/test_fixtures/accounts/accountCreate-example_01.json"
 ```
 
-## Example Using Base64-Encoded JSON String
+Using a base64-encoded JSON string:
 
 ```bash
 ./run \
     --sdk=node \
     --auth_type=apikey \
-    --auth_key=4e0a8a8bd9fea228a1de515a43a75ded2e495471b830069cc8e1821c13c31ce4 \
-    --json="ewogICJvcGVyYXRpb25JZCI6ICJhY2NvdW50Q3JlYXRlIiwKICAicGFyYW1ldGVycyI6IHt9LAogICJkYXRhIjogewogICAgImVtYWlsX2FkZHJlc3MiOiAic2lnbmVyMUBoZWxsb3NpZ24uY29tIgogIH0sCiAgImZpbGVzIjoge30KfQo="
+    --auth_key=$HS_API_KEY \
+    --json="$(printf '{"operationId":"accountCreate","parameters":{},"data":{"email_address":"test_user@example.com"},"files":{}}' | base64)"
 ```
 
-# License
+> Prefer environment variables over pasting secrets on the command line; values
+> on the command line are visible in your shell history and in `ps` output.
+
+### `--dev_mode`
+
+`--dev_mode` mounts the local `data_<sdk>/requester.*` script over the one
+baked into the image so you can iterate on the per-SDK requester code without
+rebuilding. It does **not** remount the SDK itself — to iterate on the SDK
+source, rebuild the image with `--local`:
+
+```bash
+./build --local ../dropbox-sign-python python
+```
+
+Dev mode also enables the `XDEBUG_SESSION=xdebug` cookie on outbound requests,
+which is handy when debugging the API backend. Edits to the repo-root
+[`data.json`](./data.json) (git-ignored) are picked up by dev mode.
+
+## Running the pytest suite
+
+`conftest.py` exposes fixtures the tests under `tests/` consume
+(`container_bin`, `sdk_language`, `uploads_dir`, `auth_type`, `auth_key`,
+`server`). The first one is a parametrized fixture that lets a single `pytest`
+invocation fan out across multiple SDKs.
+
+### Required environment variables
+
+| Variable | Required | Meaning |
+|---|---|---|
+| `LANGUAGES` | yes* | Comma-separated list of SDKs to exercise, e.g. `python,node`. |
+| `LANGUAGE` | yes* | Single SDK; kept for backwards compatibility. |
+| `API_KEY` | yes | Dropbox Sign API key. |
+| `SERVER` | yes | API host (no scheme), e.g. `api.qa-hellosign.com`. |
+
+\* Either `LANGUAGES` or `LANGUAGE` must be set. Prefer `LANGUAGES` — it turns
+`pytest tests/` into a matrix run across every SDK you list.
+
+Auth type is pinned to `apikey` in `conftest.py`.
+
+### Examples
+
+Run every test against a single SDK:
+
+```bash
+LANGUAGE=python \
+API_KEY=$HS_API_KEY \
+SERVER=api.qa-hellosign.com \
+pytest -svra tests/
+```
+
+Run every test against every SDK (matrix) in one process:
+
+```bash
+LANGUAGES=python,node,php,ruby,java,dotnet \
+API_KEY=$HS_API_KEY \
+SERVER=api.qa-hellosign.com \
+pytest -svra tests/
+```
+
+Tests come out as `test_create_account_success[python]`,
+`test_create_account_success[node]`, etc. Filter a subset with `-k`:
+
+```bash
+LANGUAGES=python,node,php,ruby,java,dotnet \
+API_KEY=$HS_API_KEY \
+SERVER=api.qa-hellosign.com \
+pytest -svra tests/test_account.py -k "python or node"
+```
+
+Run a single test on a single SDK:
+
+```bash
+LANGUAGE=python API_KEY=$HS_API_KEY SERVER=api.qa-hellosign.com \
+pytest -svra tests/test_signature_request.py::test_signature_request_send
+```
+
+Run the matrix with per-SDK reports in parallel processes (`&` + `wait`), one
+pytest per SDK:
+
+```bash
+for lang in python node php ruby java dotnet; do
+    LANGUAGE=$lang API_KEY=$HS_API_KEY SERVER=api.qa-hellosign.com \
+        pytest -svra tests/ --junitxml=reports/${lang}.xml &
+done
+wait
+```
+
+> Tests hit the real API. Keep matrix runs pointed at QA or staging
+> (`api.qa-hellosign.com` / `api.staging-hellosign.com`), not production.
+
+## JSON payload shape
+
+The `--json` file (or base64 blob) passed to `./run` must conform to:
+
+```json
+{
+    "operationId": "<string>",
+    "data": {},
+    "parameters": {},
+    "files": {}
+}
+```
+
+### `operationId` (required)
+
+Must match an `operationId` in the
+[OpenAPI spec's `paths` object](https://github.com/hellosign/hellosign-openapi/blob/oas-release/openapi.yaml).
+For example:
+
+```yaml
+paths:
+  /account/create:
+    post:
+      tags: [Account]
+      summary: 'Create Account'
+      operationId: accountCreate
+```
+
+### `data`
+
+Request body. Must be an object (may be empty).
+
+### `parameters`
+
+Query / path parameters. For example, `GET /account` takes an `account_id`
+query parameter.
+
+### `files`
+
+Files to upload, if the endpoint supports them. Every filename must live in
+`--uploads_dir` (default `./file_uploads`). For endpoints that accept several
+files, use a nested array:
+
+```json
+"files": { "files": ["pdf-sample.pdf", "pdf-sample-2.pdf"] }
+```
+
+### JSON payload examples
+
+Get an account (query parameter, no body):
+
+```json
+{
+    "operationId": "accountGet",
+    "parameters": { "account_id": "test_account_id" },
+    "data": {},
+    "files": {}
+}
+```
+
+Create an API App with a file upload:
+
+```json
+{
+    "operationId": "apiAppCreate",
+    "parameters": {},
+    "data": {
+        "name": "My Production App",
+        "callback_url": "https://example.com/callback",
+        "domains": ["example.com"],
+        "oauth": {
+            "callback_url": "https://example.com/oauth",
+            "scopes": ["basic_account_info", "request_signature"]
+        }
+    },
+    "files": { "custom_logo_file": "pdf-sample.pdf" }
+}
+```
+
+Send a signature request with multiple file uploads:
+
+```json
+{
+    "operationId": "signatureRequestSend",
+    "parameters": {},
+    "data": {
+        "cc_email_addresses": ["test_user@example.com"],
+        "signers": [
+            {
+                "email_address": "test_user@example.com",
+                "name": "Test Signer",
+                "order": 0
+            }
+        ],
+        "subject": "The NDA we talked about",
+        "test_mode": true,
+        "title": "NDA with Acme Co."
+    },
+    "files": { "files": ["pdf-sample.pdf", "pdf-sample-2.pdf"] }
+}
+```
+
+More examples live under [`./test_fixtures`](./test_fixtures).
+
+## Response shape
+
+Every response — success or error — comes back as:
+
+```json
+{
+    "body": {},
+    "status_code": 0,
+    "headers": {}
+}
+```
+
+Header names are always lowercased. A successful response looks like:
+
+```json
+{
+    "body": {
+        "account": {
+            "account_id": "test_account_id",
+            "email_address": "test_user@example.com",
+            "is_locked": false,
+            "is_paid_hs": false,
+            "is_paid_hf": false,
+            "quotas": { "api_signature_requests_left": 0, "documents_left": 3, "templates_left": 0 },
+            "locale": "en-US"
+        }
+    },
+    "status_code": 200,
+    "headers": { "content-type": "application/json" }
+}
+```
+
+An error response looks like:
+
+```json
+{
+    "body": {
+        "error": { "error_msg": "Unauthorized api key", "error_name": "unauthorized" }
+    },
+    "status_code": 401,
+    "headers": { "content-type": "application/json" }
+}
+```
+
+## Troubleshooting
+
+- **`${SELECTED_SDK,,}: bad substitution`** — the scripts used Bash 4 syntax
+  that macOS's system Bash 3.2 does not support. The current `./build` uses
+  portable `tr` instead; pull the latest version if you see this.
+- **Node image build fails on axios `.d.ts`** — TypeScript is too old. The
+  image now uses TypeScript 5.x with `skipLibCheck: true` to insulate against
+  third-party typing churn.
+- **Java image build fails with `com.github.hellosign:dropbox-sign-java:main-SNAPSHOT`
+  not found** — the harness now pulls the published `com.dropbox.sign:dropbox-sign`
+  artifact from Maven Central rather than JitPack. Override with
+  `./build --sdk-ref=<version> java`.
+- **.NET build complains about incompatible target framework** — the upstream
+  SDK targets `net8.0`; the image uses `mcr.microsoft.com/dotnet/sdk:8.0`. If
+  upstream bumps its target, bump the base image in `data_dotnet/Dockerfile`.
+- **`LANGUAGES` / `LANGUAGE` missing** — `conftest.py` now fails loudly rather
+  than defaulting to an arbitrary SDK. Set one of them before running pytest.
+
+## License
 
 Unless otherwise noted:
 
-```
+```text
 Copyright (c) 2023 Dropbox, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/README.md
+++ b/README.md
@@ -9,8 +9,62 @@ test suite.
 Supported SDKs: `dotnet`, `java`, `node`, `php`, `python`, `ruby` (`csharp` is
 accepted as an alias for `dotnet`).
 
-See [`./demo`](./demo) for an example of how to embed the harness in your own
+See `[./demo](./demo)` for an example of how to embed the harness in your own
 test code.
+
+## Quickstart
+
+```bash
+# 1. Build all SDK images (or just the ones you care about, e.g. ./build python)
+./build all
+
+# 2. Point at production and drop in a Dropbox Sign API key tied to a
+#    test account. Keep tests in test_mode (see "Safety" below).
+export API_KEY="YOUR_DROPBOX_SIGN_API_KEY"
+export SERVER="api.hellosign.com"
+
+# 3. Run the pytest suite against one SDK...
+LANGUAGE=python pytest -svra tests/
+
+# ...or fan the same tests out across every SDK in one go
+LANGUAGES=python,node,php,ruby,java,dotnet pytest -svra tests/
+```
+
+Firing a single request (no pytest) instead:
+
+```bash
+./run \
+    --sdk=python \
+    --auth_type=apikey \
+    --auth_key="$API_KEY" \
+    --server=api.hellosign.com \
+    --json="${PWD}/test_fixtures/accounts/accountCreate-example_01.json"
+```
+
+> **Safety**: the harness talks to the real Dropbox Sign API. Use an API key
+> bound to a dedicated test account, and keep `test_mode: true` in payloads
+> that create signature requests or unclaimed drafts. Rotate the key if it
+> ever lands in shell history, CI logs, or a screenshot.
+
+## Environment variables
+
+The pytest suite and helper utilities read the following variables. `./run`
+itself only takes CLI flags — it does not read env vars.
+
+
+| Variable                          | Scope        | Required | Default | Meaning                                                                                                                                  |
+| --------------------------------- | ------------ | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `API_KEY`                         | pytest       | yes      | —       | Dropbox Sign API key used for every request issued by the suite.                                                                         |
+| `SERVER`                          | pytest       | yes      | —       | API host (no scheme). Production is `api.hellosign.com`.                                                                                 |
+| `LANGUAGES`                       | pytest       | yes\*    | —       | Comma-separated list of SDKs to exercise, e.g. `python,node`. Turns `pytest tests/` into a matrix run.                                   |
+| `LANGUAGE`                        | pytest       | yes\*    | —       | Single SDK; kept for backwards compatibility. Set exactly one of `LANGUAGES` / `LANGUAGE`.                                               |
+| `TEMPLATE_ID`                     | pytest       | no       | —       | Template id for `test_get_template`. When unset the fixture fetches the first template returned by `/v3/template/list`; skips if empty. |
+| `CLIENT_ID`                       | pytest       | no       | —       | API-App `client_id` for embedded / unclaimed-draft tests. When unset the fixture uses the first app returned by `/v3/api_app/list`.     |
+| `SDK_TESTER_RATE_LIMIT_RETRIES`   | pytest       | no       | `3`     | How many times `helpers_hsapi.run` retries on HTTP 429 before giving up.                                                                 |
+| `SDK_TESTER_RATE_LIMIT_BACKOFF`   | pytest       | no       | `7`     | Fallback backoff in seconds when the API does not return `Retry-After` / `X-Ratelimit-Reset`.                                            |
+
+\* Either `LANGUAGES` or `LANGUAGE` must be set. `conftest.py` fails loudly
+rather than defaulting to an arbitrary SDK.
 
 ## Prerequisites
 
@@ -31,11 +85,13 @@ test code.
 
 Options:
 
-| Flag | Meaning |
-|---|---|
+
+| Flag            | Meaning                                                                                                                                                                                    |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `--sdk-ref REF` | Git ref (branch/tag/commit) for SDKs sourced from git (`python`, `ruby`, `node`, `dotnet`). For `java` this is the Maven Central version. For `php` it is the Composer version constraint. |
-| `--local PATH` | Build against a local SDK source directory instead of fetching it from git / a package registry. Mutually exclusive with `all`. |
-| `--help` | Show help and exit. |
+| `--local PATH`  | Build against a local SDK source directory instead of fetching it from git / a package registry. Mutually exclusive with `all`.                                                            |
+| `--help`        | Show help and exit.                                                                                                                                                                        |
+
 
 `SDK` is one of `dotnet java node php python ruby` or `all` (or `csharp` as an
 alias for `dotnet`). Examples:
@@ -50,14 +106,16 @@ alias for `dotnet`). Examples:
 
 ### Where each SDK comes from
 
-| SDK | Default source | Definition file |
-|---|---|---|
-| python | `github.com/hellosign/dropbox-sign-python @ main` | `data_python/requirements.txt` |
-| ruby | `github.com/hellosign/dropbox-sign-ruby @ main` | `data_ruby/Gemfile` |
-| node | `github:hellosign/dropbox-sign-node#main` | `data_node/package.json` |
-| dotnet | `github.com/hellosign/dropbox-sign-dotnet @ main` (cloned inside the image) | `data_dotnet/Dockerfile` |
-| php | Packagist `dropbox/sign ^1.0.0` | `data_php/composer.json` |
-| java | Maven Central `com.dropbox.sign:dropbox-sign:2.5.0` | `data_java/pom.xml` |
+
+| SDK    | Default source                                                              | Definition file                |
+| ------ | --------------------------------------------------------------------------- | ------------------------------ |
+| python | `github.com/hellosign/dropbox-sign-python @ main`                           | `data_python/requirements.txt` |
+| ruby   | `github.com/hellosign/dropbox-sign-ruby @ main`                             | `data_ruby/Gemfile`            |
+| node   | `github:hellosign/dropbox-sign-node#main`                                   | `data_node/package.json`       |
+| dotnet | `github.com/hellosign/dropbox-sign-dotnet @ main` (cloned inside the image) | `data_dotnet/Dockerfile`       |
+| php    | Packagist `dropbox/sign ^1.0.0`                                             | `data_php/composer.json`       |
+| java   | Maven Central `com.dropbox.sign:dropbox-sign:2.5.0`                         | `data_java/pom.xml`            |
+
 
 `--sdk-ref` rewrites the relevant descriptor in a staged build context (under
 `.build-ctx/<sdk>/`, git-ignored) so the originals in `data_<sdk>/` are never
@@ -79,16 +137,18 @@ the copy so the build context stays small.
 ./run [options]
 ```
 
-| Flag | Required | Description |
-|---|---|---|
-| `--sdk=<sdk>` | yes | `dotnet`, `java`, `node`, `php`, `python`, `ruby` (or `csharp`). |
-| `--auth_type=<type>` | yes | `apikey` or `oauth`. |
-| `--auth_key=<value>` | yes | API key (for `apikey`) or OAuth bearer token (for `oauth`). |
-| `--json=<path or b64>` | yes | Either a path to a JSON file or a base64-encoded JSON string. |
-| `--server=<host>` | no | API host (no scheme). Defaults to `api.hellosign.com`. |
-| `--uploads_dir=<path>` | no | Directory mounted at `/file_uploads`. Defaults to `./file_uploads`. |
-| `--dev_mode` | no | Mount the local `data_<sdk>/requester.*` over the one baked into the image (see note below). |
-| `--help` | no | Show help and exit. |
+
+| Flag                   | Required | Description                                                                                  |
+| ---------------------- | -------- | -------------------------------------------------------------------------------------------- |
+| `--sdk=<sdk>`          | yes      | `dotnet`, `java`, `node`, `php`, `python`, `ruby` (or `csharp`).                             |
+| `--auth_type=<type>`   | yes      | `apikey` or `oauth`.                                                                         |
+| `--auth_key=<value>`   | yes      | API key (for `apikey`) or OAuth bearer token (for `oauth`).                                  |
+| `--json=<path or b64>` | yes      | Either a path to a JSON file or a base64-encoded JSON string.                                |
+| `--server=<host>`      | no       | API host (no scheme). Defaults to `api.hellosign.com`.                                       |
+| `--uploads_dir=<path>` | no       | Directory mounted at `/file_uploads`. Defaults to `./file_uploads`.                          |
+| `--dev_mode`           | no       | Mount the local `data_<sdk>/requester.*` over the one baked into the image (see note below). |
+| `--help`               | no       | Show help and exit.                                                                          |
+
 
 `./run` mounts `--uploads_dir` at `/file_uploads` in the container; any file
 names used under `files` in your JSON payload must live in that directory.
@@ -131,7 +191,7 @@ source, rebuild the image with `--local`:
 
 Dev mode also enables the `XDEBUG_SESSION=xdebug` cookie on outbound requests,
 which is handy when debugging the API backend. Edits to the repo-root
-[`data.json`](./data.json) (git-ignored) are picked up by dev mode.
+`[data.json](./data.json)` (git-ignored) are picked up by dev mode.
 
 ## Running the pytest suite
 
@@ -140,19 +200,9 @@ which is handy when debugging the API backend. Edits to the repo-root
 `server`). The first one is a parametrized fixture that lets a single `pytest`
 invocation fan out across multiple SDKs.
 
-### Required environment variables
-
-| Variable | Required | Meaning |
-|---|---|---|
-| `LANGUAGES` | yes* | Comma-separated list of SDKs to exercise, e.g. `python,node`. |
-| `LANGUAGE` | yes* | Single SDK; kept for backwards compatibility. |
-| `API_KEY` | yes | Dropbox Sign API key. |
-| `SERVER` | yes | API host (no scheme), e.g. `api.qa-hellosign.com`. |
-
-\* Either `LANGUAGES` or `LANGUAGE` must be set. Prefer `LANGUAGES` — it turns
-`pytest tests/` into a matrix run across every SDK you list.
-
-Auth type is pinned to `apikey` in `conftest.py`.
+See [Environment variables](#environment-variables) above for the full list of
+variables the suite understands. Auth type is pinned to `apikey` in
+`conftest.py`.
 
 ### Examples
 
@@ -161,7 +211,7 @@ Run every test against a single SDK:
 ```bash
 LANGUAGE=python \
 API_KEY=$HS_API_KEY \
-SERVER=api.qa-hellosign.com \
+SERVER=api.hellosign.com \
 pytest -svra tests/
 ```
 
@@ -170,7 +220,7 @@ Run every test against every SDK (matrix) in one process:
 ```bash
 LANGUAGES=python,node,php,ruby,java,dotnet \
 API_KEY=$HS_API_KEY \
-SERVER=api.qa-hellosign.com \
+SERVER=api.hellosign.com \
 pytest -svra tests/
 ```
 
@@ -180,14 +230,17 @@ Tests come out as `test_create_account_success[python]`,
 ```bash
 LANGUAGES=python,node,php,ruby,java,dotnet \
 API_KEY=$HS_API_KEY \
-SERVER=api.qa-hellosign.com \
+SERVER=api.hellosign.com \
 pytest -svra tests/test_account.py -k "python or node"
 ```
 
-Run a single test on a single SDK:
+Run a single test on a single SDK, pinning the template it resolves:
 
 ```bash
-LANGUAGE=python API_KEY=$HS_API_KEY SERVER=api.qa-hellosign.com \
+LANGUAGE=python \
+API_KEY=$HS_API_KEY \
+SERVER=api.hellosign.com \
+TEMPLATE_ID=<your_template_id> \
 pytest -svra tests/test_signature_request.py::test_signature_request_send
 ```
 
@@ -196,14 +249,15 @@ pytest per SDK:
 
 ```bash
 for lang in python node php ruby java dotnet; do
-    LANGUAGE=$lang API_KEY=$HS_API_KEY SERVER=api.qa-hellosign.com \
+    LANGUAGE=$lang API_KEY=$HS_API_KEY SERVER=api.hellosign.com \
         pytest -svra tests/ --junitxml=reports/${lang}.xml &
 done
 wait
 ```
 
-> Tests hit the real API. Keep matrix runs pointed at QA or staging
-> (`api.qa-hellosign.com` / `api.staging-hellosign.com`), not production.
+> Tests hit the real API. Use an API key bound to a dedicated test account
+> and keep payloads that create signature requests or unclaimed drafts in
+> `test_mode: true` so real documents are never dispatched.
 
 ## JSON payload shape
 
@@ -307,7 +361,7 @@ Send a signature request with multiple file uploads:
 }
 ```
 
-More examples live under [`./test_fixtures`](./test_fixtures).
+More examples live under `[./test_fixtures](./test_fixtures)`.
 
 ## Response shape
 
@@ -355,21 +409,21 @@ An error response looks like:
 
 ## Troubleshooting
 
-- **`${SELECTED_SDK,,}: bad substitution`** — the scripts used Bash 4 syntax
-  that macOS's system Bash 3.2 does not support. The current `./build` uses
-  portable `tr` instead; pull the latest version if you see this.
+- `**${SELECTED_SDK,,}: bad substitution**` — the scripts used Bash 4 syntax
+that macOS's system Bash 3.2 does not support. The current `./build` uses
+portable `tr` instead; pull the latest version if you see this.
 - **Node image build fails on axios `.d.ts`** — TypeScript is too old. The
-  image now uses TypeScript 5.x with `skipLibCheck: true` to insulate against
-  third-party typing churn.
+image now uses TypeScript 5.x with `skipLibCheck: true` to insulate against
+third-party typing churn.
 - **Java image build fails with `com.github.hellosign:dropbox-sign-java:main-SNAPSHOT`
-  not found** — the harness now pulls the published `com.dropbox.sign:dropbox-sign`
-  artifact from Maven Central rather than JitPack. Override with
-  `./build --sdk-ref=<version> java`.
+not found** — the harness now pulls the published `com.dropbox.sign:dropbox-sign`
+artifact from Maven Central rather than JitPack. Override with
+`./build --sdk-ref=<version> java`.
 - **.NET build complains about incompatible target framework** — the upstream
-  SDK targets `net8.0`; the image uses `mcr.microsoft.com/dotnet/sdk:8.0`. If
-  upstream bumps its target, bump the base image in `data_dotnet/Dockerfile`.
-- **`LANGUAGES` / `LANGUAGE` missing** — `conftest.py` now fails loudly rather
-  than defaulting to an arbitrary SDK. Set one of them before running pytest.
+SDK targets `net8.0`; the image uses `mcr.microsoft.com/dotnet/sdk:8.0`. If
+upstream bumps its target, bump the base image in `data_dotnet/Dockerfile`.
+- `**LANGUAGES` / `LANGUAGE` missing** — `conftest.py` now fails loudly rather
+than defaulting to an arbitrary SDK. Set one of them before running pytest.
 
 ## License
 
@@ -390,3 +444,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ```
+

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Options:
 
 | Flag            | Meaning                                                                                                                                                                                    |
 | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `--sdk-ref REF` | Git ref (branch/tag/commit) for SDKs sourced from git (`python`, `ruby`, `node`, `dotnet`). For `java` this is the Maven Central version. For `php` it is the Composer version constraint. |
+| `--sdk-ref REF` | Git ref (branch/tag/commit) for SDKs sourced from git (`python`, `ruby`, `node`, `dotnet`). For `java` this is the Maven Central version (defaults to the latest `<release>` published on Maven Central). For `php` it is the Composer version constraint. |
 | `--local PATH`  | Build against a local SDK source directory instead of fetching it from git / a package registry. Mutually exclusive with `all`.                                                            |
 | `--help`        | Show help and exit.                                                                                                                                                                        |
 
@@ -100,7 +100,7 @@ alias for `dotnet`). Examples:
 ./build all                          # build every SDK from defaults
 ./build python                       # build just python
 ./build --sdk-ref=v1.4.0 node        # pin node to a specific upstream ref
-./build --sdk-ref=2.5.0  java        # pin java to a specific Maven version
+./build --sdk-ref=2.6.0 java         # pin java to a specific Maven Central release
 ./build --local ../dropbox-sign-python python   # build against a local SDK
 ```
 
@@ -114,7 +114,7 @@ alias for `dotnet`). Examples:
 | node   | `github:hellosign/dropbox-sign-node#main`                                   | `data_node/package.json`       |
 | dotnet | `github.com/hellosign/dropbox-sign-dotnet @ main` (cloned inside the image) | `data_dotnet/Dockerfile`       |
 | php    | Packagist `dropbox/sign ^1.0.0`                                             | `data_php/composer.json`       |
-| java   | Maven Central `com.dropbox.sign:dropbox-sign:2.5.0`                         | `data_java/pom.xml`            |
+| java   | Maven Central `com.dropbox.sign:dropbox-sign` (latest `<release>`)          | `data_java/pom.xml`            |
 
 
 `--sdk-ref` rewrites the relevant descriptor in a staged build context (under
@@ -123,6 +123,14 @@ touched. `--local` does the same plus copies your local SDK into the context
 at `./sdk-src/` and rewrites the descriptor to reference `/sdk-src` inside the
 container (for Java it `mvn install`s the local SDK into the image-local Maven
 repo and pins the tester's `pom.xml` to the version in the local `pom.xml`).
+
+For Java, `./build java` with no `--sdk-ref` fetches
+`https://repo1.maven.org/maven2/com/dropbox/sign/dropbox-sign/maven-metadata.xml`
+and pins the staged `pom.xml` to the `<release>` value it reports — so the
+default tracks "latest published Maven Central release" the same way the git
+based SDKs track `main`. If that fetch fails (offline, Maven Central outage)
+the build falls back to the `<version>` baked into `data_java/pom.xml` and
+prints a warning.
 
 ### How `./build` runs the SDK
 
@@ -417,8 +425,14 @@ image now uses TypeScript 5.x with `skipLibCheck: true` to insulate against
 third-party typing churn.
 - **Java image build fails with `com.github.hellosign:dropbox-sign-java:main-SNAPSHOT`
 not found** — the harness now pulls the published `com.dropbox.sign:dropbox-sign`
-artifact from Maven Central rather than JitPack. Override with
-`./build --sdk-ref=<version> java`.
+artifact from Maven Central rather than JitPack. By default `./build java`
+auto-resolves the latest `<release>` from `maven-metadata.xml`; to pin a
+specific version pass `./build --sdk-ref=<version> java`.
+- **Java build prints `could not resolve latest Java version from Maven
+Central`** — the `maven-metadata.xml` fetch failed (offline, DNS, proxy).
+The build falls back to the `<version>` pinned in `data_java/pom.xml`; if
+that is too old, re-run with an explicit `--sdk-ref=<version> java` once the
+network is back.
 - **.NET build complains about incompatible target framework** — the upstream
 SDK targets `net8.0`; the image uses `mcr.microsoft.com/dotnet/sdk:8.0`. If
 upstream bumps its target, bump the base image in `data_dotnet/Dockerfile`.

--- a/build
+++ b/build
@@ -1,73 +1,360 @@
 #!/usr/bin/env bash
 
 set -e
-DIR=$(cd `dirname $0` && pwd)
-AVAILABLE_SDKS=("csharp dotnet java node php python ruby")
-SELECTED_SDK=$1
+DIR=$(cd "$(dirname "$0")" && pwd)
+AVAILABLE_SDKS=(dotnet java node php python ruby)
+
+SELECTED_SDK=""
+SDK_REF=""
+LOCAL_SDK=""
 
 main() {
-  touch "${DIR}/data.json"
+    touch "${DIR}/data.json"
 
-  if [[ -z "${SELECTED_SDK}" ]]; then
-      show_help
-      exit 0
-  fi
+    parse_args "$@"
 
-  # lowercase
-  SELECTED_SDK="${SELECTED_SDK,,}"
+    if [[ -z "${SELECTED_SDK}" ]]; then
+        show_help
+        exit 0
+    fi
 
-  if [[ ${SELECTED_SDK} == "all" ]]; then
-      build_container node
-      build_container php
-      build_container python
-      build_container ruby
-      build_container java
-      build_container dotnet
-      exit 0
-  fi
+    SELECTED_SDK=$(printf '%s' "${SELECTED_SDK}" | tr '[:upper:]' '[:lower:]')
 
-  if [[ ${SELECTED_SDK} == "csharp" ]]; then
-    SELECTED_SDK="dotnet"
-  fi
+    if [[ "${SELECTED_SDK}" == "csharp" ]]; then
+        SELECTED_SDK="dotnet"
+    fi
 
-  if [[ ! " ${AVAILABLE_SDKS[*]} " =~ " ${SELECTED_SDK} " ]]; then
-      printf "Invalid SDK selected: ${SELECTED_SDK}\n"
-      show_help
-      exit 1
-  fi
+    if [[ "${SELECTED_SDK}" == "all" ]]; then
+        if [[ -n "${LOCAL_SDK}" ]]; then
+            printf "Error: --local cannot be combined with 'all'. Pick a single SDK.\n" >&2
+            exit 1
+        fi
+        for sdk in "${AVAILABLE_SDKS[@]}"; do
+            build_container "${sdk}"
+        done
+        exit 0
+    fi
 
-  build_container ${SELECTED_SDK}
-  exit 0
+    local found=0
+    for sdk in "${AVAILABLE_SDKS[@]}"; do
+        if [[ "${sdk}" == "${SELECTED_SDK}" ]]; then
+            found=1
+            break
+        fi
+    done
+    if [[ "${found}" -ne 1 ]]; then
+        printf "Invalid SDK selected: %s\n" "${SELECTED_SDK}" >&2
+        show_help
+        exit 1
+    fi
+
+    build_container "${SELECTED_SDK}"
 }
 
-function show_help() {
-    cat << EOF
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --sdk-ref=*)  SDK_REF="${1#*=}" ;;
+            --sdk-ref)    SDK_REF="$2"; shift ;;
+            --local=*)    LOCAL_SDK="${1#*=}" ;;
+            --local)      LOCAL_SDK="$2"; shift ;;
+            --help|-h)    show_help; exit 0 ;;
+            --)           shift; SELECTED_SDK="$1" ;;
+            -*)
+                printf "Unknown option: %s\n" "$1" >&2
+                show_help
+                exit 1
+                ;;
+            *)
+                if [[ -n "${SELECTED_SDK}" ]]; then
+                    printf "Unexpected extra argument: %s\n" "$1" >&2
+                    show_help
+                    exit 1
+                fi
+                SELECTED_SDK="$1"
+                ;;
+        esac
+        shift
+    done
+
+    if [[ -n "${LOCAL_SDK}" ]]; then
+        if [[ ! -d "${LOCAL_SDK}" ]]; then
+            printf "Error: --local path is not a directory: %s\n" "${LOCAL_SDK}" >&2
+            exit 1
+        fi
+        LOCAL_SDK=$(cd "${LOCAL_SDK}" && pwd)
+    fi
+}
+
+show_help() {
+    cat <<EOF
 Builds one or all SDK containers.
 
-To create containers for all the SDKs:
+Usage:
+    ./build [options] SDK
+
+Options:
+    --sdk-ref REF    Git ref (branch/tag/commit) for SDKs sourced from git.
+                     For Java it is interpreted as the Maven Central version.
+                     For PHP it is interpreted as the Composer version constraint.
+    --local PATH     Build against a local SDK source directory instead of
+                     fetching from git / a package registry. Cannot be combined
+                     with 'all'.
+    --help           Show this help and exit.
+
+SDK can be one of: ${AVAILABLE_SDKS[*]} (or 'all', or 'csharp' as an alias for dotnet).
+
+Examples:
     ./build all
-
-To create a container for a single SDK:
-    ./build [SDK]
-
-SDK can be one of "dotnet", "java", "node", "php", "python", "ruby"
-
+    ./build python
+    ./build --sdk-ref=v1.4.0 node
+    ./build --local ../dropbox-sign-python python
 EOF
 }
 
-function build_container()
-{
-    SELECTED_SDK=$1
-
-    IMG_NAME="dropbox/sign-${SELECTED_SDK}"
-    printf "Building the ${SELECTED_SDK} container\n\n"
-    docker image build \
-        --no-cache \
-        -t ${IMG_NAME}:latest \
-        -f data_${SELECTED_SDK}/Dockerfile \
-        ./data_${SELECTED_SDK}
-    printf "\nSuccessfully created image ${IMG_NAME}\n"
+sed_inplace() {
+    if sed --version >/dev/null 2>&1; then
+        sed -i "$@"
+    else
+        sed -i '' "$@"
+    fi
 }
 
-main "$@";
+stage_context() {
+    local sdk="$1"
+    local src="${DIR}/data_${sdk}"
+    local ctx="${DIR}/.build-ctx/${sdk}"
+
+    rm -rf "${ctx}"
+    mkdir -p "${ctx}"
+    cp -R "${src}/." "${ctx}/"
+
+    if [[ -n "${LOCAL_SDK}" ]]; then
+        mkdir -p "${ctx}/sdk-src"
+        if command -v rsync >/dev/null 2>&1; then
+            rsync -a --delete \
+                --exclude='.git' \
+                --exclude='node_modules' \
+                --exclude='vendor' \
+                --exclude='target' \
+                --exclude='build' \
+                --exclude='dist' \
+                --exclude='bin' \
+                --exclude='obj' \
+                --exclude='__pycache__' \
+                --exclude='*.egg-info' \
+                --exclude='.venv' \
+                --exclude='venv' \
+                "${LOCAL_SDK}/" "${ctx}/sdk-src/"
+        else
+            cp -R "${LOCAL_SDK}/." "${ctx}/sdk-src/"
+        fi
+        apply_local "${sdk}" "${ctx}"
+    elif [[ -n "${SDK_REF}" ]]; then
+        apply_sdk_ref "${sdk}" "${ctx}"
+    fi
+
+    echo "${ctx}"
+}
+
+apply_sdk_ref() {
+    local sdk="$1"
+    local ctx="$2"
+
+    case "${sdk}" in
+        python)
+            printf 'git+https://github.com/hellosign/dropbox-sign-python.git@%s\n' "${SDK_REF}" \
+                > "${ctx}/requirements.txt"
+            ;;
+        ruby)
+            cat > "${ctx}/Gemfile" <<EOF
+source 'https://rubygems.org'
+
+gem 'dropbox-sign',
+  git: 'https://github.com/hellosign/dropbox-sign-ruby.git',
+  branch: '${SDK_REF}'
+EOF
+            ;;
+        node)
+            sed_inplace \
+                -e "s|github:hellosign/dropbox-sign-node#[^\"]*|github:hellosign/dropbox-sign-node#${SDK_REF}|" \
+                "${ctx}/package.json"
+            ;;
+        dotnet)
+            sed_inplace \
+                -e "s|git checkout [^ ]*|git checkout ${SDK_REF}|" \
+                "${ctx}/Dockerfile"
+            ;;
+        java)
+            python3 - "${ctx}/pom.xml" "${SDK_REF}" <<'PY'
+import re, sys
+path, ref = sys.argv[1], sys.argv[2]
+with open(path) as f:
+    xml = f.read()
+xml = re.sub(
+    r'(<groupId>com\.dropbox\.sign</groupId>\s*<artifactId>dropbox-sign</artifactId>\s*<version>)[^<]+(</version>)',
+    lambda m: m.group(1) + ref + m.group(2),
+    xml,
+    count=1,
+)
+with open(path, 'w') as f:
+    f.write(xml)
+PY
+            ;;
+        php)
+            sed_inplace \
+                -e "s|\"dropbox/sign\": \"[^\"]*\"|\"dropbox/sign\": \"${SDK_REF}\"|" \
+                "${ctx}/composer.json"
+            ;;
+    esac
+}
+
+apply_local() {
+    local sdk="$1"
+    local ctx="$2"
+
+    case "${sdk}" in
+        python)
+            cat > "${ctx}/requirements.txt" <<'EOF'
+/sdk-src
+EOF
+            sed_inplace \
+                -e 's|^COPY \./requirements.txt /app/requirements.txt$|COPY ./sdk-src /sdk-src\nCOPY ./requirements.txt /app/requirements.txt|' \
+                "${ctx}/Dockerfile"
+            ;;
+        ruby)
+            cat > "${ctx}/Gemfile" <<'EOF'
+source 'https://rubygems.org'
+
+gem 'dropbox-sign', path: '/sdk-src'
+EOF
+            sed_inplace \
+                -e 's|^COPY \./Gemfile /app/Gemfile$|COPY ./sdk-src /sdk-src\nCOPY ./Gemfile /app/Gemfile|' \
+                "${ctx}/Dockerfile"
+            ;;
+        node)
+            python3 - "${ctx}/package.json" <<'PY'
+import json, sys
+path = sys.argv[1]
+with open(path) as f:
+    pkg = json.load(f)
+pkg.setdefault('dependencies', {})['@dropbox/sign'] = 'file:/sdk-src'
+with open(path, 'w') as f:
+    json.dump(pkg, f, indent=2)
+    f.write('\n')
+PY
+            sed_inplace \
+                -e 's|^COPY \./package.json /app/package.json$|COPY ./sdk-src /sdk-src\nCOPY ./package.json /app/package.json|' \
+                "${ctx}/Dockerfile"
+            ;;
+        php)
+            python3 - "${ctx}/composer.json" <<'PY'
+import json, sys
+path = sys.argv[1]
+with open(path) as f:
+    cfg = json.load(f)
+cfg['repositories'] = [{
+    'type': 'path',
+    'url': '/sdk-src',
+    'options': {'symlink': False},
+}]
+cfg.setdefault('require', {})['dropbox/sign'] = '*@dev'
+cfg['minimum-stability'] = 'dev'
+with open(path, 'w') as f:
+    json.dump(cfg, f, indent=4)
+    f.write('\n')
+PY
+            sed_inplace \
+                -e 's|^COPY \./composer.json /app/composer.json$|COPY ./sdk-src /sdk-src\nCOPY ./composer.json /app/composer.json|' \
+                "${ctx}/Dockerfile"
+            ;;
+        java)
+            local local_version
+            local_version=$(python3 - "${LOCAL_SDK}/pom.xml" <<'PY'
+import re, sys
+with open(sys.argv[1]) as f:
+    xml = f.read()
+m = re.search(r'<project\b[^>]*>.*?<version>([^<]+)</version>', xml, re.DOTALL)
+print(m.group(1) if m else '', end='')
+PY
+            )
+            if [[ -z "${local_version}" ]]; then
+                printf "Error: could not read <version> from local Java SDK pom.xml\n" >&2
+                exit 1
+            fi
+            python3 - "${ctx}/pom.xml" "${local_version}" <<'PY'
+import re, sys
+path, version = sys.argv[1], sys.argv[2]
+with open(path) as f:
+    xml = f.read()
+xml = re.sub(
+    r'(<groupId>com\.dropbox\.sign</groupId>\s*<artifactId>dropbox-sign</artifactId>\s*<version>)[^<]+(</version>)',
+    lambda m: m.group(1) + version + m.group(2),
+    xml,
+    count=1,
+)
+with open(path, 'w') as f:
+    f.write(xml)
+PY
+            sed_inplace \
+                -e 's|RUN cd /app && \\|RUN cd /sdk-src \&\& mvn install -DskipTests -q \&\& cd /app \&\&|' \
+                "${ctx}/Dockerfile"
+            sed_inplace \
+                -e 's|^COPY \./pom.xml /app/pom.xml$|COPY ./sdk-src /sdk-src\nCOPY ./pom.xml /app/pom.xml|' \
+                "${ctx}/Dockerfile"
+            ;;
+        dotnet)
+            python3 - "${ctx}/Dockerfile" <<'PY'
+import sys
+path = sys.argv[1]
+with open(path) as f:
+    text = f.read()
+new_block = (
+    "COPY ./sdk-src /app/dropbox-sign-dotnet\n"
+    "\n"
+    "RUN cd /app/dropbox-sign-dotnet && \\\n"
+    "    dotnet new console -o sdk-tester && \\\n"
+    "    mv /app/Program.cs sdk-tester && \\\n"
+    "    dotnet add sdk-tester/sdk-tester.csproj reference src/Dropbox.Sign/Dropbox.Sign.csproj && \\\n"
+    "    dotnet build\n"
+)
+old_block_start = "RUN cd /app && \\"
+idx = text.find(old_block_start)
+if idx == -1:
+    sys.exit("could not find dotnet RUN block to rewrite")
+end = text.find("dotnet build", idx)
+if end == -1:
+    sys.exit("could not find end of dotnet RUN block")
+end = text.find("\n", end) + 1
+text = text[:idx] + new_block + text[end:]
+with open(path, 'w') as f:
+    f.write(text)
+PY
+            ;;
+    esac
+}
+
+build_container() {
+    local sdk="$1"
+    local ctx
+    ctx=$(stage_context "${sdk}")
+
+    local img="dropbox/sign-${sdk}"
+    printf "\n==> Building the %s container\n" "${sdk}"
+    if [[ -n "${LOCAL_SDK}" ]]; then
+        printf "    using local SDK: %s\n" "${LOCAL_SDK}"
+    elif [[ -n "${SDK_REF}" ]]; then
+        printf "    using SDK ref:   %s\n" "${SDK_REF}"
+    fi
+
+    docker image build \
+        --no-cache \
+        -t "${img}:latest" \
+        -f "${ctx}/Dockerfile" \
+        "${ctx}"
+
+    printf "\nSuccessfully created image %s\n" "${img}"
+}
+
+main "$@"
 exit

--- a/build
+++ b/build
@@ -95,7 +95,10 @@ Usage:
 
 Options:
     --sdk-ref REF    Git ref (branch/tag/commit) for SDKs sourced from git.
-                     For Java it is interpreted as the Maven Central version.
+                     For Java it is interpreted as the Maven Central version;
+                     when omitted, ./build java fetches the latest <release>
+                     from Maven Central and falls back to the version pinned
+                     in data_java/pom.xml if the fetch fails.
                      For PHP it is interpreted as the Composer version constraint.
     --local PATH     Build against a local SDK source directory instead of
                      fetching from git / a package registry. Cannot be combined
@@ -120,8 +123,34 @@ sed_inplace() {
     fi
 }
 
+# Fetch the latest <release> version of com.dropbox.sign:dropbox-sign from
+# Maven Central and print it on stdout. Returns non-zero if the fetch fails
+# or the metadata cannot be parsed; callers should fall back to whatever is
+# pinned in data_java/pom.xml.
+resolve_java_latest() {
+    local metadata_url="https://repo1.maven.org/maven2/com/dropbox/sign/dropbox-sign/maven-metadata.xml"
+    local metadata
+    if ! metadata=$(curl -fsSL --max-time 15 "${metadata_url}" 2>/dev/null); then
+        return 1
+    fi
+    local version
+    version=$(printf '%s' "${metadata}" | python3 -c '
+import re, sys
+text = sys.stdin.read()
+m = re.search(r"<release>([^<]+)</release>", text)
+if not m:
+    m = re.search(r"<latest>([^<]+)</latest>", text)
+sys.stdout.write(m.group(1) if m else "")
+')
+    if [[ -z "${version}" ]]; then
+        return 1
+    fi
+    printf '%s' "${version}"
+}
+
 stage_context() {
     local sdk="$1"
+    local ref="${2:-}"
     local src="${DIR}/data_${sdk}"
     local ctx="${DIR}/.build-ctx/${sdk}"
 
@@ -150,8 +179,8 @@ stage_context() {
             cp -R "${LOCAL_SDK}/." "${ctx}/sdk-src/"
         fi
         apply_local "${sdk}" "${ctx}"
-    elif [[ -n "${SDK_REF}" ]]; then
-        apply_sdk_ref "${sdk}" "${ctx}"
+    elif [[ -n "${ref}" ]]; then
+        apply_sdk_ref "${sdk}" "${ctx}" "${ref}"
     fi
 
     echo "${ctx}"
@@ -160,10 +189,11 @@ stage_context() {
 apply_sdk_ref() {
     local sdk="$1"
     local ctx="$2"
+    local ref="${3:-${SDK_REF}}"
 
     case "${sdk}" in
         python)
-            printf 'git+https://github.com/hellosign/dropbox-sign-python.git@%s\n' "${SDK_REF}" \
+            printf 'git+https://github.com/hellosign/dropbox-sign-python.git@%s\n' "${ref}" \
                 > "${ctx}/requirements.txt"
             ;;
         ruby)
@@ -172,38 +202,48 @@ source 'https://rubygems.org'
 
 gem 'dropbox-sign',
   git: 'https://github.com/hellosign/dropbox-sign-ruby.git',
-  branch: '${SDK_REF}'
+  branch: '${ref}'
 EOF
             ;;
         node)
             sed_inplace \
-                -e "s|github:hellosign/dropbox-sign-node#[^\"]*|github:hellosign/dropbox-sign-node#${SDK_REF}|" \
+                -e "s|github:hellosign/dropbox-sign-node#[^\"]*|github:hellosign/dropbox-sign-node#${ref}|" \
                 "${ctx}/package.json"
             ;;
         dotnet)
             sed_inplace \
-                -e "s|git checkout [^ ]*|git checkout ${SDK_REF}|" \
+                -e "s|git checkout [^ ]*|git checkout ${ref}|" \
                 "${ctx}/Dockerfile"
             ;;
         java)
-            python3 - "${ctx}/pom.xml" "${SDK_REF}" <<'PY'
+            python3 - "${ctx}/pom.xml" "${ref}" <<'PY'
 import re, sys
 path, ref = sys.argv[1], sys.argv[2]
 with open(path) as f:
     xml = f.read()
-xml = re.sub(
-    r'(<groupId>com\.dropbox\.sign</groupId>\s*<artifactId>dropbox-sign</artifactId>\s*<version>)[^<]+(</version>)',
+# Allow whitespace and/or XML comments between <artifactId> and <version>.
+pattern = re.compile(
+    r'(<groupId>com\.dropbox\.sign</groupId>'
+    r'\s*<artifactId>dropbox-sign</artifactId>'
+    r'(?:\s|<!--[\s\S]*?-->)*'
+    r'<version>)[^<]+(</version>)'
+)
+new_xml, count = pattern.subn(
     lambda m: m.group(1) + ref + m.group(2),
     xml,
     count=1,
 )
+if count != 1:
+    sys.exit(
+        f"apply_sdk_ref(java): could not locate the dropbox-sign <version> in {path}"
+    )
 with open(path, 'w') as f:
-    f.write(xml)
+    f.write(new_xml)
 PY
             ;;
         php)
             sed_inplace \
-                -e "s|\"dropbox/sign\": \"[^\"]*\"|\"dropbox/sign\": \"${SDK_REF}\"|" \
+                -e "s|\"dropbox/sign\": \"[^\"]*\"|\"dropbox/sign\": \"${ref}\"|" \
                 "${ctx}/composer.json"
             ;;
     esac
@@ -287,14 +327,23 @@ import re, sys
 path, version = sys.argv[1], sys.argv[2]
 with open(path) as f:
     xml = f.read()
-xml = re.sub(
-    r'(<groupId>com\.dropbox\.sign</groupId>\s*<artifactId>dropbox-sign</artifactId>\s*<version>)[^<]+(</version>)',
+pattern = re.compile(
+    r'(<groupId>com\.dropbox\.sign</groupId>'
+    r'\s*<artifactId>dropbox-sign</artifactId>'
+    r'(?:\s|<!--[\s\S]*?-->)*'
+    r'<version>)[^<]+(</version>)'
+)
+new_xml, count = pattern.subn(
     lambda m: m.group(1) + version + m.group(2),
     xml,
     count=1,
 )
+if count != 1:
+    sys.exit(
+        f"apply_local(java): could not locate the dropbox-sign <version> in {path}"
+    )
 with open(path, 'w') as f:
-    f.write(xml)
+    f.write(new_xml)
 PY
             sed_inplace \
                 -e 's|RUN cd /app && \\|RUN cd /sdk-src \&\& mvn install -DskipTests -q \&\& cd /app \&\&|' \
@@ -336,15 +385,31 @@ PY
 
 build_container() {
     local sdk="$1"
+    local effective_ref="${SDK_REF}"
+    local ref_source="cli"
+
+    if [[ -z "${effective_ref}" && -z "${LOCAL_SDK}" && "${sdk}" == "java" ]]; then
+        if effective_ref=$(resolve_java_latest); then
+            ref_source="maven-central"
+        else
+            effective_ref=""
+            printf "    warning: could not resolve latest Java version from Maven Central; falling back to the version pinned in data_java/pom.xml\n" >&2
+        fi
+    fi
+
     local ctx
-    ctx=$(stage_context "${sdk}")
+    ctx=$(stage_context "${sdk}" "${effective_ref}")
 
     local img="dropbox/sign-${sdk}"
     printf "\n==> Building the %s container\n" "${sdk}"
     if [[ -n "${LOCAL_SDK}" ]]; then
         printf "    using local SDK: %s\n" "${LOCAL_SDK}"
-    elif [[ -n "${SDK_REF}" ]]; then
-        printf "    using SDK ref:   %s\n" "${SDK_REF}"
+    elif [[ -n "${effective_ref}" ]]; then
+        if [[ "${ref_source}" == "maven-central" ]]; then
+            printf "    using SDK ref:   %s (auto-resolved latest from Maven Central)\n" "${effective_ref}"
+        else
+            printf "    using SDK ref:   %s\n" "${effective_ref}"
+        fi
     fi
 
     docker image build \

--- a/conftest.py
+++ b/conftest.py
@@ -26,12 +26,38 @@ def container_bin():
 
     # Grab the following from config file, environment, or somewhere else
     #
-@pytest.fixture(scope='module')
-def sdk_language():
-    # One of "node", "php", "python", "ruby", "dotnet", "java"
-    sdk_language = os.environ['LANGUAGE']
-    print(f"SDK Language : {sdk_language}")
-    return sdk_language
+SUPPORTED_LANGUAGES = ("node", "php", "python", "ruby", "dotnet", "java")
+
+
+def _selected_languages():
+    """Resolve the set of SDK languages to exercise.
+
+    Priority:
+      1. LANGUAGES env var (comma-separated list, e.g. "python,node").
+      2. LANGUAGE env var (single SDK) — kept for backwards compatibility.
+      3. No default — fail loudly so a stray run cannot silently hit every SDK.
+    """
+    raw = os.environ.get("LANGUAGES") or os.environ.get("LANGUAGE")
+    if not raw:
+        raise RuntimeError(
+            "Set LANGUAGES (comma-separated) or LANGUAGE (single value). "
+            f"Supported: {', '.join(SUPPORTED_LANGUAGES)}."
+        )
+
+    langs = [item.strip().lower() for item in raw.split(",") if item.strip()]
+    unknown = [item for item in langs if item not in SUPPORTED_LANGUAGES]
+    if unknown:
+        raise RuntimeError(
+            f"Unsupported language(s): {', '.join(unknown)}. "
+            f"Supported: {', '.join(SUPPORTED_LANGUAGES)}."
+        )
+    return langs
+
+
+def pytest_generate_tests(metafunc):
+    if "sdk_language" in metafunc.fixturenames:
+        langs = _selected_languages()
+        metafunc.parametrize("sdk_language", langs, scope="module", ids=lambda v: v)
 
 @pytest.fixture(scope='module')
 def uploads_dir():
@@ -70,6 +96,45 @@ def get_clientid():
         client_id = res_json['api_apps'][0]['client_id']
         print(f"\nClient ID :: {client_id}")
         return client_id
+
+
+@pytest.fixture(scope='module')
+def get_template_id():
+    """Resolve a template id to use for ``test_get_template``.
+
+    Resolution order:
+      1. ``TEMPLATE_ID`` env var (explicit override).
+      2. First template returned by ``/v3/template/list`` for the
+         configured API key.
+      3. ``None`` — the test should skip in this case.
+    """
+    override = os.environ.get('TEMPLATE_ID')
+    if override:
+        print(f"\nUsing TEMPLATE_ID override :: {override}")
+        return override
+
+    try:
+        res = helpers_hsapi.get_list_templates(page_size=30)
+    except Exception as exc:  # network / DNS / auth header issues
+        print(f"\nCould not list templates: {exc!r}")
+        return None
+
+    if res.status_code != 200:
+        print(f"\ntemplate/list returned {res.status_code}: {res.text[:500]}")
+        return None
+
+    try:
+        res_json = json.loads(res.text)
+    except json.JSONDecodeError:
+        return None
+
+    templates = res_json.get('templates') or []
+    if not templates:
+        return None
+
+    template_id = templates[0].get('template_id')
+    print(f"\nResolved Template ID :: {template_id}")
+    return template_id
     # for app_num in range(len(res_json['api_apps'])):
     #     if res_json['api_apps'][app_num]['name'] == HS_API_APP:
     #         # Get the client_id

--- a/conftest.py
+++ b/conftest.py
@@ -87,15 +87,41 @@ def server():
 
 @pytest.fixture(scope='module')
 def get_clientid():
-    #HS_API_APP = 'Automation APP'
-    res = helpers_hsapi.get_list_api_apps(page_size=30)
-    res_json = json.loads(res.text)
-    print(f"\nget list apps {res_json}")
-    assert res.status_code == 200
-    if len(res_json['api_apps']) > 0:
-        client_id = res_json['api_apps'][0]['client_id']
-        print(f"\nClient ID :: {client_id}")
-        return client_id
+    """Resolve an API-app ``client_id`` for tests that need one.
+
+    Resolution order:
+      1. ``CLIENT_ID`` env var (explicit override).
+      2. First API app returned by ``/v3/api_app/list`` for the
+         configured API key.
+      3. ``None`` — the caller should skip in this case.
+    """
+    override = os.environ.get('CLIENT_ID')
+    if override:
+        print(f"\nUsing CLIENT_ID override :: {override}")
+        return override
+
+    try:
+        res = helpers_hsapi.get_list_api_apps(page_size=30)
+    except Exception as exc:
+        print(f"\nCould not list api apps: {exc!r}")
+        return None
+
+    if res.status_code != 200:
+        print(f"\napi_app/list returned {res.status_code}: {res.text[:500]}")
+        return None
+
+    try:
+        res_json = json.loads(res.text)
+    except json.JSONDecodeError:
+        return None
+
+    api_apps = res_json.get('api_apps') or []
+    if not api_apps:
+        return None
+
+    client_id = api_apps[0].get('client_id')
+    print(f"\nResolved Client ID :: {client_id}")
+    return client_id
 
 
 @pytest.fixture(scope='module')

--- a/data_dotnet/Dockerfile
+++ b/data_dotnet/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0
+FROM mcr.microsoft.com/dotnet/sdk:8.0
 LABEL maintainer="Dropbox Sign API Team <apisupport@hellosign.com>"
 
 USER root

--- a/data_java/pom.xml
+++ b/data_java/pom.xml
@@ -17,6 +17,13 @@
         <dependency>
             <groupId>com.dropbox.sign</groupId>
             <artifactId>dropbox-sign</artifactId>
+            <!--
+              Fallback version. `./build java` rewrites this in the staged
+              build context to whatever <release> is currently published
+              in Maven Central, or to the explicit version passed to the
+              build script. This pinned value is only used when Maven
+              Central is unreachable at build time.
+            -->
             <version>2.5.0</version>
         </dependency>
         <dependency>

--- a/data_java/pom.xml
+++ b/data_java/pom.xml
@@ -13,17 +13,11 @@
         <maven.compiler.target>11</maven.compiler.target>
     </properties>
 
-    <repositories>
-        <repository>
-            <id>jitpack.io</id>
-            <url>https://jitpack.io</url>
-        </repository>
-    </repositories>
     <dependencies>
         <dependency>
-            <groupId>com.github.hellosign</groupId>
-            <artifactId>dropbox-sign-java</artifactId>
-            <version>main-SNAPSHOT</version>
+            <groupId>com.dropbox.sign</groupId>
+            <artifactId>dropbox-sign</artifactId>
+            <version>2.5.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/data_node/Dockerfile
+++ b/data_node/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:17
+FROM node:20
 LABEL maintainer="Dropbox Sign API Team <apisupport@hellosign.com>"
 
 USER root

--- a/data_node/package.json
+++ b/data_node/package.json
@@ -8,8 +8,8 @@
     "@dropbox/sign": "github:hellosign/dropbox-sign-node#main"
   },
   "devDependencies": {
-    "@types/node": "^17.0.10",
-    "ts-node": "^10.4.0",
-    "typescript": "^3.9.5"
+    "@types/node": "^20.11.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.0"
   }
 }

--- a/data_node/tsconfig.json
+++ b/data_node/tsconfig.json
@@ -2,8 +2,8 @@
   "compilerOptions": {
     "module": "commonjs",
     "noImplicitAny": false,
-    "suppressImplicitAnyIndexErrors": true,
     "target": "ES6",
+    "skipLibCheck": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "strict": true,

--- a/data_php/Dockerfile
+++ b/data_php/Dockerfile
@@ -1,7 +1,17 @@
-FROM jtreminio/php-cli:7.4
+FROM php:8.3-cli
 LABEL maintainer="Dropbox Sign API Team <apisupport@hellosign.com>"
 
 USER root
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        git \
+        unzip \
+        libzip-dev && \
+    docker-php-ext-install zip && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
 
 RUN mkdir /file_uploads && \
     mkdir /test_fixtures && \

--- a/data_python/requester.py
+++ b/data_python/requester.py
@@ -37,18 +37,35 @@ class Requester(object):
             response = self._call_from_operation_id()
 
             data = {
-                'body': response[0].to_dict(),
-                'status_code': response[1],
-                'headers': self._get_response_headers(response[2]),
+                'body': response.data.to_dict() if response.data is not None else None,
+                'status_code': response.status_code,
+                'headers': self._get_response_headers(response.headers or {}),
             }
         except ApiException as e:
             data = {
-                'body': e.body.to_dict(),
+                'body': self._exception_body(e),
                 'status_code': e.status,
-                'headers': self._get_response_headers(e.headers),
+                'headers': self._get_response_headers(e.headers or {}),
             }
 
         print(json.dumps(data, indent=4))
+
+    @staticmethod
+    def _exception_body(exc: ApiException):
+        if getattr(exc, 'data', None) is not None and hasattr(exc.data, 'to_dict'):
+            return exc.data.to_dict()
+        body = getattr(exc, 'body', None)
+        if isinstance(body, (bytes, bytearray)):
+            try:
+                body = body.decode('utf-8')
+            except UnicodeDecodeError:
+                return None
+        if isinstance(body, str) and body:
+            try:
+                return json.loads(body)
+            except json.JSONDecodeError:
+                return {'raw': body}
+        return None
 
     def _get_config(self):
         if self._auth_type == 'apikey':
@@ -128,10 +145,14 @@ class Requester(object):
         raise RuntimeError(f'Invalid operationId: {self._operation_id}')
 
     @staticmethod
-    def _get_response_headers(headers: dict):
+    def _get_response_headers(headers):
         formatted = {}
 
-        for key, value in headers.items():
+        if not headers:
+            return formatted
+
+        items = headers.items() if hasattr(headers, 'items') else headers
+        for key, value in items:
             formatted[key.lower()] = value
 
         return formatted
@@ -157,70 +178,54 @@ class Requester(object):
         if self._operation_id == 'accountCreate':
             obj = m.AccountCreateRequest.init(self._data)
 
-            return api.account_create(
-                obj,
-                _return_http_data_only=False
-            )
+            return api.account_create_with_http_info(obj)
 
         if self._operation_id == 'accountGet':
-            return api.account_get(
+            return api.account_get_with_http_info(
                 account_id=self._parameters.get('account_id', None),
                 email_address=self._parameters.get('email_address', None),
-                _return_http_data_only=False
             )
 
         if self._operation_id == 'accountUpdate':
             obj = m.AccountUpdateRequest.init(self._data)
 
-            return api.account_update(
-                obj,
-                _return_http_data_only=False
-            )
+            return api.account_update_with_http_info(obj)
 
         if self._operation_id == 'accountVerify':
             obj = m.AccountVerifyRequest.init(self._data)
 
-            return api.account_verify(
-                obj,
-                _return_http_data_only=False
-            )
+            return api.account_verify_with_http_info(obj)
 
     def _api_app_api(self):
         api = apis.ApiAppApi(self._api_client)
 
         if self._operation_id == 'apiAppCreate':
             obj = m.ApiAppCreateRequest.init(self._data)
-            obj['custom_logo_file'] = self._get_file('custom_logo_file')
+            obj.custom_logo_file = self._get_file('custom_logo_file')
 
-            return api.api_app_create(
-                obj,
-                _return_http_data_only=False
-            )
+            return api.api_app_create_with_http_info(obj)
 
         if self._operation_id == 'apiAppDelete':
-            return api.api_app_delete(
+            return api.api_app_delete_with_http_info(
                 self._parameters.get('client_id'),
-                _return_http_data_only=False
             )
 
         if self._operation_id == 'apiAppGet':
-            return api.api_app_get(
+            return api.api_app_get_with_http_info(
                 self._parameters.get('client_id'),
-                _return_http_data_only=False
             )
 
         if self._operation_id == 'apiAppList':
-            return api.api_app_list(
+            return api.api_app_list_with_http_info(
                 page=self._parameters.get('page', 1),
                 page_size=self._parameters.get('page_size', 20),
-                _return_http_data_only=False
             )
 
         if self._operation_id == 'apiAppUpdate':
             obj = m.ApiAppUpdateRequest.init(self._data)
-            obj['custom_logo_file'] = self._get_file('custom_logo_file')
+            obj.custom_logo_file = self._get_file('custom_logo_file')
 
-            return api.api_app_update(
+            return api.api_app_update_with_http_info(
                 self._parameters.get('client_id'),
                 obj,
             )
@@ -229,16 +234,14 @@ class Requester(object):
         api = apis.BulkSendJobApi(self._api_client)
 
         if self._operation_id == 'bulkSendJobGet':
-            return api.bulk_send_job_get(
+            return api.bulk_send_job_get_with_http_info(
                 self._parameters.get('bulk_send_job_id'),
-                _return_http_data_only=False
             )
 
         if self._operation_id == 'bulkSendJobList':
-            return api.bulk_send_job_list(
+            return api.bulk_send_job_list_with_http_info(
                 page=self._parameters.get('page', 1),
                 page_size=self._parameters.get('page_size', 20),
-                _return_http_data_only=False
             )
 
     def _embedded_api(self):
@@ -247,16 +250,14 @@ class Requester(object):
         if self._operation_id == 'embeddedEditUrl':
             obj = m.EmbeddedEditUrlRequest.init(self._data)
 
-            return api.embedded_edit_url(
+            return api.embedded_edit_url_with_http_info(
                 self._parameters.get('template_id'),
                 obj,
-                _return_http_data_only=False
             )
 
         if self._operation_id == 'embeddedSignUrl':
-            return api.embedded_sign_url(
+            return api.embedded_sign_url_with_http_info(
                 self._parameters.get('signature_id'),
-                _return_http_data_only=False
             )
 
     def _oauth_api(self):
@@ -265,18 +266,12 @@ class Requester(object):
         if self._operation_id == 'oauthTokenGenerate':
             obj = m.OAuthTokenGenerateRequest.init(self._data)
 
-            return api.oauth_token_generate(
-                obj,
-                _return_http_data_only=False
-            )
+            return api.oauth_token_generate_with_http_info(obj)
 
         if self._operation_id == 'oauthTokenRefresh':
             obj = m.OAuthTokenRefreshRequest.init(self._data)
 
-            return api.oauth_token_refresh(
-                obj,
-                _return_http_data_only=False
-            )
+            return api.oauth_token_refresh_with_http_info(obj)
 
     def _report_api(self):
         api = apis.ReportApi(self._api_client)
@@ -284,123 +279,94 @@ class Requester(object):
         if self._operation_id == 'reportCreate':
             obj = m.ReportCreateRequest.init(self._data)
 
-            return api.report_create(
-                obj,
-                _return_http_data_only=False
-            )
+            return api.report_create_with_http_info(obj)
 
     def _signature_request_api(self):
         api = apis.SignatureRequestApi(self._api_client)
 
         if self._operation_id == 'signatureRequestBulkCreateEmbeddedWithTemplate':
             obj = m.SignatureRequestBulkCreateEmbeddedWithTemplateRequest.init(self._data)
-            obj['signer_file'] = self._get_file('signer_file')
+            obj.signer_file = self._get_file('signer_file')
 
-            return api.signature_request_bulk_create_embedded_with_template(
-                obj,
-                _return_http_data_only=False
-            )
+            return api.signature_request_bulk_create_embedded_with_template_with_http_info(obj)
 
         if self._operation_id == 'signatureRequestBulkSendWithTemplate':
             obj = m.SignatureRequestBulkSendWithTemplateRequest.init(self._data)
-            obj['signer_file'] = self._get_file('signer_file')
+            obj.signer_file = self._get_file('signer_file')
 
-            return api.signature_request_bulk_send_with_template(
-                obj,
-                _return_http_data_only=False
-            )
+            return api.signature_request_bulk_send_with_template_with_http_info(obj)
 
         if self._operation_id == 'signatureRequestCancel':
-            return api.signature_request_cancel(
+            return api.signature_request_cancel_with_http_info(
                 self._parameters.get('signature_request_id'),
-                _return_http_data_only=False
             )
 
         if self._operation_id == 'signatureRequestCreateEmbedded':
             obj = m.SignatureRequestCreateEmbeddedRequest.init(self._data)
-            obj['files'] = self._get_files('files')
+            obj.files = self._get_files('files')
 
-            return api.signature_request_create_embedded(
-                obj,
-                _return_http_data_only=False
-            )
+            return api.signature_request_create_embedded_with_http_info(obj)
 
         if self._operation_id == 'signatureRequestCreateEmbeddedWithTemplate':
             obj = m.SignatureRequestCreateEmbeddedWithTemplateRequest.init(self._data)
-            obj['files'] = self._get_files('files')
+            obj.files = self._get_files('files')
 
-            return api.signature_request_create_embedded_with_template(
-                obj,
-                _return_http_data_only=False
-            )
+            return api.signature_request_create_embedded_with_template_with_http_info(obj)
 
         if self._operation_id == 'signatureRequestFilesAsFileUrl':
-            return api.signature_request_files_as_file_url(
+            return api.signature_request_files_as_file_url_with_http_info(
                 self._parameters.get('signature_request_id'),
-                _return_http_data_only=False
             )
 
         if self._operation_id == 'signatureRequestGet':
-            return api.signature_request_get(
+            return api.signature_request_get_with_http_info(
                 self._parameters.get('signature_request_id'),
-                _return_http_data_only=False
             )
 
         if self._operation_id == 'signatureRequestList':
-            return api.signature_request_list(
+            return api.signature_request_list_with_http_info(
                 account_id=self._parameters.get('account_id', None),
                 page=self._parameters.get('page', 1),
                 page_size=self._parameters.get('page_size', 20),
                 query=self._parameters.get('query', None),
-                _return_http_data_only=False
             )
 
         if self._operation_id == 'signatureRequestReleaseHold':
-            return api.signature_request_release_hold(
+            return api.signature_request_release_hold_with_http_info(
                 self._parameters.get('signature_request_id'),
-                _return_http_data_only=False
             )
 
         if self._operation_id == 'signatureRequestRemind':
             obj = m.SignatureRequestRemindRequest.init(self._data)
 
-            return api.signature_request_remind(
+            return api.signature_request_remind_with_http_info(
                 self._parameters.get('signature_request_id'),
                 obj,
-                _return_http_data_only=False
             )
 
         if self._operation_id == 'signatureRequestRemove':
-            return api.signature_request_remove(
+            return api.signature_request_remove_with_http_info(
                 self._parameters.get('signature_request_id'),
-                _return_http_data_only=False
             )
 
         if self._operation_id == 'signatureRequestSend':
             obj = m.SignatureRequestSendRequest.init(self._data)
-            obj['files'] = self._get_files('files')
+            obj.files = self._get_files('files')
 
-            return api.signature_request_send(
-                obj,
-                _return_http_data_only=False
-            )
+            return api.signature_request_send_with_http_info(obj)
 
         if self._operation_id == 'signatureRequestSendWithTemplate':
             obj = m.SignatureRequestSendWithTemplateRequest.init(self._data)
-            obj['files'] = self._get_files('files')
+            obj.files = self._get_files('files')
 
-            return api.signature_request_send_with_template(
-                obj,
-                _return_http_data_only=False
-            )
+            return api.signature_request_send_with_template_with_http_info(obj)
 
         if self._operation_id == 'signatureRequestUpdate':
             obj = m.SignatureRequestUpdateRequest.init(self._data)
 
-            return api.signature_request_update(
+            return api.signature_request_update_with_http_info(
                 self._parameters.get('signature_request_id'),
                 obj,
-                _return_http_data_only=False
             )
 
     def _team_api(self):
@@ -409,45 +375,31 @@ class Requester(object):
         if self._operation_id == 'teamAddMember':
             obj = m.TeamAddMemberRequest.init(self._data)
 
-            return api.team_add_member(
+            return api.team_add_member_with_http_info(
                 obj,
                 team_id=self._parameters.get('team_id', None),
-                _return_http_data_only=False
             )
 
         if self._operation_id == 'teamCreate':
             obj = m.TeamCreateRequest.init(self._data)
 
-            return api.team_create(
-                obj,
-                _return_http_data_only=False
-            )
+            return api.team_create_with_http_info(obj)
 
         if self._operation_id == 'teamDelete':
-            return api.team_delete(
-                _return_http_data_only=False
-            )
+            return api.team_delete_with_http_info()
 
         if self._operation_id == 'teamGet':
-            return api.team_get(
-                _return_http_data_only=False
-            )
+            return api.team_get_with_http_info()
 
         if self._operation_id == 'teamRemoveMember':
             obj = m.TeamRemoveMemberRequest.init(self._data)
 
-            return api.team_update(
-                obj,
-                _return_http_data_only=False
-            )
+            return api.team_update_with_http_info(obj)
 
         if self._operation_id == 'teamUpdate':
             obj = m.TeamUpdateRequest.init(self._data)
 
-            return api.team_update(
-                obj,
-                _return_http_data_only=False
-            )
+            return api.team_update_with_http_info(obj)
 
     def _template_api(self):
         api = apis.TemplateApi(self._api_client)
@@ -455,65 +407,55 @@ class Requester(object):
         if self._operation_id == 'templateAddUser':
             obj = m.TemplateAddUserRequest.init(self._data)
 
-            return api.template_add_user(
+            return api.template_add_user_with_http_info(
                 self._parameters.get('template_id', None),
                 obj,
-                _return_http_data_only=False
             )
 
         if self._operation_id == 'templateCreateEmbeddedDraft':
             obj = m.TemplateCreateEmbeddedDraftRequest.init(self._data)
-            obj['files'] = self._get_files('files')
+            obj.files = self._get_files('files')
 
-            return api.template_create_embedded_draft(
-                obj,
-                _return_http_data_only=False
-            )
+            return api.template_create_embedded_draft_with_http_info(obj)
 
         if self._operation_id == 'templateDelete':
-            return api.template_delete(
+            return api.template_delete_with_http_info(
                 self._parameters.get('template_id'),
-                _return_http_data_only=False
             )
 
         if self._operation_id == 'templateFilesAsFileUrl':
-            return api.template_files_as_file_url(
+            return api.template_files_as_file_url_with_http_info(
                 self._parameters.get('template_id'),
-                _return_http_data_only=False
             )
 
         if self._operation_id == 'templateGet':
-            return api.template_get(
+            return api.template_get_with_http_info(
                 self._parameters.get('template_id'),
-                _return_http_data_only=False
             )
 
         if self._operation_id == 'templateList':
-            return api.template_list(
+            return api.template_list_with_http_info(
                 account_id=self._parameters.get('account_id', None),
                 page=self._parameters.get('page', 1),
                 page_size=self._parameters.get('page_size', 20),
                 query=self._parameters.get('query', None),
-                _return_http_data_only=False
             )
 
         if self._operation_id == 'templateRemoveUser':
             obj = m.TemplateRemoveUserRequest.init(self._data)
 
-            return api.template_remove_user(
+            return api.template_remove_user_with_http_info(
                 self._parameters.get('template_id'),
                 obj,
-                _return_http_data_only=False
             )
 
         if self._operation_id == 'templateUpdateFiles':
             obj = m.TemplateUpdateFilesRequest.init(self._data)
-            obj['files'] = self._get_files('files')
+            obj.files = self._get_files('files')
 
-            return api.template_update_files(
+            return api.template_update_files_with_http_info(
                 self._parameters.get('template_id'),
                 obj,
-                _return_http_data_only=False
             )
 
     def _unclaimed_draft_api(self):
@@ -521,38 +463,28 @@ class Requester(object):
 
         if self._operation_id == 'unclaimedDraftCreate':
             obj = m.UnclaimedDraftCreateRequest.init(self._data)
-            obj['files'] = self._get_files('files')
+            obj.files = self._get_files('files')
 
-            return api.unclaimed_draft_create(
-                obj,
-                _return_http_data_only=False
-            )
+            return api.unclaimed_draft_create_with_http_info(obj)
 
         if self._operation_id == 'unclaimedDraftCreateEmbedded':
             obj = m.UnclaimedDraftCreateEmbeddedRequest.init(self._data)
-            obj['files'] = self._get_files('files')
+            obj.files = self._get_files('files')
 
-            return api.unclaimed_draft_create_embedded(
-                obj,
-                _return_http_data_only=False
-            )
+            return api.unclaimed_draft_create_embedded_with_http_info(obj)
 
         if self._operation_id == 'unclaimedDraftCreateEmbeddedWithTemplate':
             obj = m.UnclaimedDraftCreateEmbeddedWithTemplateRequest.init(self._data)
-            obj['files'] = self._get_files('files')
+            obj.files = self._get_files('files')
 
-            return api.unclaimed_draft_create_embedded_with_template(
-                obj,
-                _return_http_data_only=False
-            )
+            return api.unclaimed_draft_create_embedded_with_template_with_http_info(obj)
 
         if self._operation_id == 'unclaimedDraftEditAndResend':
             obj = m.UnclaimedDraftEditAndResendRequest.init(self._data)
 
-            return api.unclaimed_draft_edit_and_resend(
+            return api.unclaimed_draft_edit_and_resend_with_http_info(
                 self._parameters.get('signature_request_id'),
                 obj,
-                _return_http_data_only=False
             )
 
 

--- a/demo/main.py
+++ b/demo/main.py
@@ -71,7 +71,7 @@ class ApiTester(object):
 
 
 def test_create_account_success(tester: ApiTester):
-    email_address = f'signer{uuid.uuid4()}@hellosign.com'
+    email_address = f'signer{uuid.uuid4()}@example.com'
 
     json_data = {
         "operationId": "accountCreate",
@@ -122,10 +122,10 @@ def test_signature_request_create_embedded(tester: ApiTester):
                 }
             ],
             "cc_email_addresses": [
-                "hs-api-qa+sdk+cc1@hellosign.com",
-                "hs-api-qa+sdk+cc2@hellosign.com"
+                "cc1@example.com",
+                "cc2@example.com"
             ],
-            "client_id": "efdbab0dd86acda1aaa3d56ea3ded8cf",
+            "client_id": "YOUR_CLIENT_ID",
             "custom_fields": [
                 {
                     "name": "Cost",
@@ -160,12 +160,12 @@ def test_signature_request_create_embedded(tester: ApiTester):
             },
             "signers": [
                 {
-                    "email_address": "hs-api-qa+sdk+signer1@hellosign.com",
+                    "email_address": "signer1@example.com",
                     "name": "Jack",
                     "order": 0
                 },
                 {
-                    "email_address": "hs-api-qa+sdk+signer2@hellosign.com",
+                    "email_address": "signer2@example.com",
                     "name": "Jill",
                     "order": 1
                 }

--- a/run
+++ b/run
@@ -86,15 +86,16 @@ Example if using a JSON file:
     ./run \\
         --sdk=php \\
         --auth_type=apikey \\
-        --auth_key=4e0a8a8bd9fea228a1de515a43a75ded2e495471b830069cc8e1821c13c31ce4 \\
+        --auth_key="\$HS_API_KEY" \\
         --json="\$PWD/test_fixtures/accountCreate-example_01.json"
 
-Example if using a base64-encoded JSON string:
+Example if using a base64-encoded JSON string
+(the blob decodes to {"operationId":"accountCreate","parameters":{},"data":{"email_address":"test_user@example.com"},"files":{}}):
     ./run \\
         --sdk=php \\
         --auth_type=apikey \\
-        --auth_key=4e0a8a8bd9fea228a1de515a43a75ded2e495471b830069cc8e1821c13c31ce4 \\
-        --json="ewogICJvcGVyYXRpb25JZCI6ICJhY2NvdW50Q3JlYXRlIiwKICAicGFyYW1ldGVycyI6IHt9LAogICJkYXRhIjogewogICAgImVtYWlsX2FkZHJlc3MiOiAic2lnbmVyMUBoZWxsb3NpZ24uY29tIgogIH0sCiAgImZpbGVzIjoge30KfQo="
+        --auth_key="\$HS_API_KEY" \\
+        --json="ewogICJvcGVyYXRpb25JZCI6ICJhY2NvdW50Q3JlYXRlIiwKICAicGFyYW1ldGVycyI6IHt9LAogICJkYXRhIjogewogICAgImVtYWlsX2FkZHJlc3MiOiAidGVzdF91c2VyQGV4YW1wbGUuY29tIgogIH0sCiAgImZpbGVzIjoge30KfQo="
 EOF
 }
 

--- a/test_fixtures/accounts/accountCreate-example_01.json
+++ b/test_fixtures/accounts/accountCreate-example_01.json
@@ -2,7 +2,7 @@
   "operationId": "accountCreate",
   "parameters": {},
   "data": {
-    "email_address": "signer1@hellosign.com"
+    "email_address": "signer1@example.com"
   },
   "files": {}
 }

--- a/test_fixtures/signature_request/signatureRequestCreateEmbedded.json
+++ b/test_fixtures/signature_request/signatureRequestCreateEmbedded.json
@@ -79,7 +79,7 @@
         "api_id": "uniqueIdHere_3",
         "name": "",
         "type": "signature",
-        "x": 789,
+        "x": 400,
         "y": 567,
         "width": 120,
         "height": 30,

--- a/test_fixtures/signature_request/signatureRequestCreateEmbedded.json
+++ b/test_fixtures/signature_request/signatureRequestCreateEmbedded.json
@@ -12,8 +12,8 @@
       }
     ],
     "cc_email_addresses": [
-      "hs-api-qa+sdk+cc1@hellosign.com",
-      "hs-api-qa+sdk+cc2@hellosign.com"
+      "cc1@example.com",
+      "cc2@example.com"
     ],
     "custom_fields": [
       {
@@ -95,12 +95,12 @@
     },
     "signers": [
       {
-        "email_address": "hs-api-qa+sdk+signer1@hellosign.com",
+        "email_address": "signer1@example.com",
         "name": "Jack",
         "order": 0
       },
       {
-        "email_address": "hs-api-qa+sdk+signer2@hellosign.com",
+        "email_address": "signer2@example.com",
         "name": "Jill",
         "order": 1
       }

--- a/test_fixtures/signature_request/signatureRequestSend-example_01.json
+++ b/test_fixtures/signature_request/signatureRequestSend-example_01.json
@@ -13,7 +13,7 @@
       }
     ],
     "cc_email_addresses": [
-      "lawyer@hellosign.com",
+      "lawyer@example.com",
       "lawyer@example.com"
     ],
     "field_options": {
@@ -181,22 +181,22 @@
     },
     "signers": [
       {
-        "email_address": "hs-api-qa+sdk+signer1@hellosign.com",
+        "email_address": "signer1@example.com",
         "name": "Signer 1",
         "order": 0
       },
       {
-        "email_address": "hs-api-qa+sdk+signer2@hellosign.com",
+        "email_address": "signer2@example.com",
         "name": "Signer 2",
         "order": 1
       },
       {
-        "email_address": "hs-api-qa+sdk+signer3@hellosign.com",
+        "email_address": "signer3@example.com",
         "name": "Signer 3",
         "order": 2
       },
       {
-        "email_address": "hs-api-qa+sdk+signer4@hellosign.com",
+        "email_address": "signer4@example.com",
         "name": "Signer 4",
         "order": 3
       }

--- a/test_fixtures/signature_request/signatureRequestSend-example_01.json
+++ b/test_fixtures/signature_request/signatureRequestSend-example_01.json
@@ -14,7 +14,7 @@
     ],
     "cc_email_addresses": [
       "lawyer@example.com",
-      "lawyer@example.com"
+      "paralegal@example.com"
     ],
     "field_options": {
       "date_format": "DD - MM - YYYY"

--- a/test_fixtures/unclaimed_draft/unclaimedDraftCreateEmbedded.json
+++ b/test_fixtures/unclaimed_draft/unclaimedDraftCreateEmbedded.json
@@ -13,19 +13,19 @@
         ],
         "signers": [
             {
-                "email_address": "hs-api-qa+sdk+signer1@hellosign.com",
+                "email_address": "signer1@example.com",
                 "name": "Jack",
                 "order": 0
             },
             {
-                "email_address": "hs-api-qa+sdk+signer2@hellosign.com",
+                "email_address": "signer2@example.com",
                 "name": "Jill",
                 "order": 1
             }
         ],
         "cc_email_addresses": [
-            "hs-api-qa+sdk+cc1@hellosign.com",
-            "hs-api-qa+sdk+cc2@hellosign.com"
+            "cc1@example.com",
+            "cc2@example.com"
         ],
         "custom_fields": [
             {
@@ -107,7 +107,7 @@
             "field1": "value1"
         },
 
-      "requester_email_address": "hs-api-qa+sdk+requester@hellosign.com",
+      "requester_email_address": "requester@example.com",
         "signing_options": {
             "draw": true,
             "type": true,

--- a/test_fixtures/unclaimed_draft/unclaimedDraftCreateEmbeddedSelfSign.json
+++ b/test_fixtures/unclaimed_draft/unclaimedDraftCreateEmbeddedSelfSign.json
@@ -5,8 +5,8 @@
         "allow_reassign": true,
         "type": "send_document",
         "cc_email_addresses": [
-            "hs-api-qa+sdk+cc1@hellosign.com",
-            "hs-api-qa+sdk+cc2@hellosign.com"
+            "cc1@example.com",
+            "cc2@example.com"
         ],
         "custom_fields": [
             {
@@ -25,7 +25,7 @@
             "field1": "value1"
         },
 
-      "requester_email_address": "hs-api-qa+sdk+requester@hellosign.com",
+      "requester_email_address": "requester@example.com",
         "signing_options": {
             "draw": true,
             "type": true,

--- a/test_fixtures/unclaimed_draft/unclaimedDraftCreateEmbedded_test.json
+++ b/test_fixtures/unclaimed_draft/unclaimedDraftCreateEmbedded_test.json
@@ -18,19 +18,19 @@
         ],
         "signers": [
             {
-                "email_address": "hs-api-qa+sdk+signer1@hellosign.com",
+                "email_address": "signer1@example.com",
                 "name": "Jack",
                 "order": 0
             },
             {
-                "email_address": "hs-api-qa+sdk+signer2@hellosign.com",
+                "email_address": "signer2@example.com",
                 "name": "Jill",
                 "order": 1
             }
         ],
         "cc_email_addresses": [
-            "hs-api-qa+sdk+cc1@hellosign.com",
-            "hs-api-qa+sdk+cc2@hellosign.com"
+            "cc1@example.com",
+            "cc2@example.com"
         ],
         "custom_fields": [
             {
@@ -92,7 +92,7 @@
             "field1": "value1"
         },
 
-      "requester_email_address": "hs-api-qa+sdk+requester@hellosign.com",
+      "requester_email_address": "requester@example.com",
         "signing_options": {
             "draw": true,
             "type": true,

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -54,4 +54,11 @@ def test_create_account_failure(container_bin,sdk_language,uploads_dir,auth_type
                                  auth_key, server)
     print(f"\n\nResponse : test_create_account_failure {response}")
     assert response.status_code == 400
-    assert 'email_address not valid' in response.body['error']['error_msg']
+    error = response.body.get('error', {})
+    assert error.get('error_name') == 'bad_request', (
+        f"Expected a bad_request error for an invalid email, got {response.body!r}"
+    )
+    error_msg = (error.get('error_msg') or '').lower()
+    assert 'email' in error_msg or 'not valid' in error_msg, (
+        f"Expected the error message to mention the bad email, got {error.get('error_msg')!r}"
+    )

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -17,7 +17,7 @@ with open(accountCreate_filename, "r") as fs:
 
 
 def test_create_account_success(container_bin,sdk_language,uploads_dir,auth_type,auth_key,server):
-    email_address = f'signer+{uuid.uuid4()}@hellosign.com'
+    email_address = f'signer+{uuid.uuid4()}@example.com'
     json_data = {
         "operationId": "accountCreate",
         "parameters": {},

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -17,7 +17,7 @@ with open(accountCreate_filename, "r") as fs:
 
 
 def test_create_account_success(container_bin,sdk_language,uploads_dir,auth_type,auth_key,server):
-    email_address = f'signer+{uuid.uuid4()}@example.com'
+    email_address = f'signer-{uuid.uuid4().hex}@example.com'
     json_data = {
         "operationId": "accountCreate",
         "parameters": {},

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -2,37 +2,39 @@ import pytest
 import os
 import sys
 import json
-from pathlib import Path
 scriptdir = os.path.dirname(os.path.realpath(__file__))
 utilsdir = f'{scriptdir}/utils/'
 sys.path.insert(0, utilsdir)
 import helpers_hsapi
-import shared_records
 
 root_dir = os.path.abspath(os.curdir)
 print(f"root dir {root_dir}")
 
-def test_get_template(container_bin,sdk_language,uploads_dir,auth_type,auth_key,server,get_clientid):
+def test_get_template(container_bin, sdk_language, uploads_dir, auth_type, auth_key, server, get_template_id):
     getTemplate_filename = f'{root_dir}/test_fixtures/template/getTemplate.json'
     with open(getTemplate_filename) as json_file:
         json_decoded = json.load(json_file)
-    templateid =''
-    if server == 'api.qa-hellosign.com':
-        templateid = shared_records.qa_template_id
-    elif server == 'api.staging-hellosign.com':
-        templateid = shared_records.staging_template_id
-    elif server == 'api.hellosign.com':
-        templateid = shared_records.prod_template_id
 
-    #Append client_id into JSON.
-    #json_decoded["data"]["client_id"] = get_clientid
-    #print(f"template id {shared_records.template_id}")
-    json_decoded["parameters"]["template_id"] = templateid
-    # This step is to covert the JSON into duoble quotes. ptherwise we get error `Expecting property name enclosed in double quotes`
-    json_decoded = json.dumps(json_decoded)
-    print(f"json decoded {json_decoded}")
-    response = helpers_hsapi.run(json_decoded, container_bin, sdk_language, uploads_dir, auth_type,
+    if not get_template_id:
+        pytest.skip(
+            f"No template available for server {server!r}. "
+            "Either the API key has no templates, or set TEMPLATE_ID=<id> to override."
+        )
+
+    json_decoded["parameters"]["template_id"] = get_template_id
+    json_payload = json.dumps(json_decoded)
+    print(f"json decoded {json_payload}")
+    response = helpers_hsapi.run(json_payload, container_bin, sdk_language, uploads_dir, auth_type,
                                  auth_key, server)
 
     print(f"\n\nResponse : test_get_template {response.body}")
+
+    if response.status_code == 404:
+        error_name = (response.body.get('error') or {}).get('error_name')
+        if error_name == 'not_found':
+            pytest.skip(
+                f"Template {get_template_id!r} does not exist in {server!r}. "
+                "Set TEMPLATE_ID to a template available to this API key."
+            )
+
     assert response.status_code == 200

--- a/tests/utils/helpers_hsapi.py
+++ b/tests/utils/helpers_hsapi.py
@@ -2,11 +2,13 @@
 import json
 import os
 import subprocess
+import time
 import uuid
 from typing import NamedTuple
 import requests
 from string import Template, ascii_lowercase, digits
 import base64
+
 
 class ApiResponse(NamedTuple):
     body: dict
@@ -14,48 +16,114 @@ class ApiResponse(NamedTuple):
     headers: dict
 
 
-def run(json_dump,container_bin,sdk_language,uploads_dir,auth_type,auth_key,server):
-    #print(f"typeof {type(json_dump)}")
-    #print(f"json_dump : \n {json_dump}")
-    base64_json = base64.b64encode(json_dump.encode('utf-8'))
-    base64_json_string = base64_json.decode('utf-8')
-    #print(f"base64_json {base64_json_string}")
+def _invoke(cmd):
+    """Run the container harness once and return the parsed ApiResponse.
 
-    cmd = [
-            container_bin,
-            f'--sdk={sdk_language}',
-            f'--auth_type={auth_type}',
-            f'--auth_key={auth_key}',
-            f'--uploads_dir={uploads_dir}',
-            f'--server={server}',
-            f'--json={base64_json_string}'
-        ]
-    response = subprocess.run(
-            cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+    - Non-zero exit code is treated as an infrastructure failure; both stdout
+      and stderr are surfaced so the caller can debug.
+    - Stderr on a zero exit is treated as non-fatal noise (e.g. the
+      ``WARNING: The requested image's platform (linux/amd64) does not match
+      the detected host platform`` message emitted by Docker Desktop on ARM
+      Macs when running an amd64-only image).
+    - If stdout cannot be parsed as JSON the caller gets both streams back
+      so the real error is visible instead of an empty RuntimeError.
+    """
+    completed = subprocess.run(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
     )
-    print(f"Response  : {response}")
-    print(f"Response code : {response.returncode}")
-    if response.returncode:
+    stdout = completed.stdout.decode('utf-8', errors='replace')
+    stderr = completed.stderr.decode('utf-8', errors='replace')
+
+    if completed.returncode:
         raise RuntimeError(
-                "Error running container:\n" +
-                response.stdout.decode('utf-8')
+            "Error running container (exit {}):\nstdout:\n{}\nstderr:\n{}".format(
+                completed.returncode, stdout, stderr,
+            )
         )
 
-    if response.stderr:
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError as exc:
         raise RuntimeError(
-             "Error running container:\n" +
-            response.stderr.decode('utf-8')
-        )
-
-    payload = json.loads(response.stdout.decode('utf-8'))
+            "Container stdout was not valid JSON: {}\nstdout:\n{}\nstderr:\n{}".format(
+                exc, stdout, stderr,
+            )
+        ) from exc
 
     return ApiResponse(
         body=payload['body'],
         status_code=payload['status_code'],
         headers=payload['headers'],
     )
+
+
+def run(json_dump, container_bin, sdk_language, uploads_dir, auth_type, auth_key, server):
+    base64_json = base64.b64encode(json_dump.encode('utf-8'))
+    base64_json_string = base64_json.decode('utf-8')
+
+    cmd = [
+        container_bin,
+        f'--sdk={sdk_language}',
+        f'--auth_type={auth_type}',
+        f'--auth_key={auth_key}',
+        f'--uploads_dir={uploads_dir}',
+        f'--server={server}',
+        f'--json={base64_json_string}',
+    ]
+
+    max_retries = int(os.environ.get('SDK_TESTER_RATE_LIMIT_RETRIES', '3'))
+    default_backoff_seconds = float(
+        os.environ.get('SDK_TESTER_RATE_LIMIT_BACKOFF', '7'),
+    )
+
+    attempt = 0
+    while True:
+        response = _invoke(cmd)
+        if response.status_code != 429 or attempt >= max_retries:
+            return response
+
+        attempt += 1
+        backoff = _rate_limit_backoff(response.headers, default_backoff_seconds)
+        print(
+            f"Got 429 from API (attempt {attempt}/{max_retries}); "
+            f"sleeping {backoff:.1f}s before retry..."
+        )
+        time.sleep(backoff)
+
+
+def _rate_limit_backoff(headers, default_seconds):
+    """Honour the API's rate-limit hints when we get back a 429.
+
+    Header names come back in mixed case depending on the SDK in use
+    (Java capitalises them, most others lowercase them), so match
+    case-insensitively. Values may also be wrapped in a list by the Java
+    response shape.
+    """
+    def _get(name):
+        for key, value in (headers or {}).items():
+            if key.lower() == name.lower():
+                return value[0] if isinstance(value, list) else value
+        return None
+
+    retry_after = _get('Retry-After')
+    if retry_after:
+        try:
+            return max(float(retry_after), 1.0)
+        except (TypeError, ValueError):
+            pass
+
+    reset = _get('X-Ratelimit-Reset')
+    if reset:
+        try:
+            wait = float(reset) - time.time()
+            if wait > 0:
+                return min(wait + 1.0, 60.0)
+        except (TypeError, ValueError):
+            pass
+
+    return default_seconds
 
 
 def base64encoding(api_key):
@@ -84,4 +152,29 @@ def get_list_api_apps(page_size=30):
 
     print(f"\n Response : get_api_app: {res.status_code}")
 
+    return res
+
+
+def get_list_templates(page_size=30, query=None):
+    """List templates visible to the configured API key.
+
+    Mirrors :func:`get_list_api_apps` so tests can discover a usable template
+    id at runtime instead of relying on a hardcoded id that may have been
+    deleted on the target environment.
+    """
+    server = os.environ['SERVER']
+    auth_key = os.environ['API_KEY']
+    auth_key = str(auth_key) + ':'
+    apikey = base64encoding(auth_key)
+
+    url = f'https://{server}/v3/template/list?page_size={page_size}'
+    if query:
+        url = f'{url}&query={requests.utils.quote(query)}'
+    headers = {
+        'Authorization': f'Basic {apikey}',
+    }
+
+    print(f"\n URL %s {url}")
+    res = requests.get(url, headers=headers)
+    print(f"\n Response : get_list_templates: {res.status_code}")
     return res

--- a/tests/utils/shared_records.py
+++ b/tests/utils/shared_records.py
@@ -1,6 +1,0 @@
-
-# Template name - BulkSend Automation Test - hs-api-qa@hellosign.com
-staging_template_id = 'e16d14f75e8b1a1812278eab8461ba0326112b49'
-qa_template_id = '6e344e08072cf2693f2fd8c5aa57ed4baea1fd0c'
-#Template Name = 'template 1' for account 'hellosign_test@outlook.com'
-prod_template_id = '4e6aa24e6ffa910ada1de376b1a37c004292345b'


### PR DESCRIPTION
# Modernize sdk-tester: fix builds across all SDKs and make the suite runnable again

## Why

`./build` failed out of the gate on macOS and the vendored Dockerfiles were pinned
to toolchains / SDK refs that no longer exist. Even after building, `pytest`
crashed on most SDKs because the Python tester was written against the
pre-pydantic `dropbox-sign-python` API, fixtures were out of date, and error
reporting in `helpers_hsapi.run` swallowed the stderr that would have told us so.

This PR gets the full matrix back to green against staging (modulo one real,
upstream .NET SDK bug — see "Known issues" below) and makes it easier to pin a
specific SDK version or a local working copy when we chase regressions.

## What

### Build tooling (`165cbb6`, `cc329de`)
- `./build` now runs on the system bash that ships with macOS (bash 3.2) by
  replacing `${var,,}` with a `tr`-based lowercase.
- New flags:
  - `--sdk-ref REF` — pin the SDK git ref / package version baked into the
    image (git branch/tag for node/ruby/php/dotnet, Maven Central version
    for Java, Composer constraint for PHP).
  - `--local PATH` — build the tester against a working copy of an SDK by
    rsync'ing it into a staging build context (handy for local fixes).
- Image fixes:
  - **node**: bump to `node:20`, TypeScript `^5.4`, `@types/node ^20.11`,
    drop the removed `suppressImplicitAnyIndexErrors`, add `skipLibCheck`
    so axios type defs don't fail the build.
  - **java**: switch from the unresolvable `com.github.hellosign:dropbox-sign-java:main-SNAPSHOT`
    on jitpack.io to `com.dropbox.sign:dropbox-sign:2.5.0` on Maven Central as default. Taking the latest version from Maven at build time.
  - **dotnet**: bump base image to `mcr.microsoft.com/dotnet/sdk:8.0` so the
    tester can reference `Dropbox.Sign`, which now targets net8.0.

### Python tester (`c24d495`)
The upstream SDK regenerated its bindings using `pydantic @validate_call`,
which broke every endpoint call in the old tester:
- `_return_http_data_only=False` is no longer accepted. Every call now goes
  through `*_with_http_info(...)` which returns an `ApiResponse[T]` with
  `.data` / `.status_code` / `.headers`.
- Request bodies are pydantic models — `obj['files'] = ...` raises
  `TypeError`. Switched to attribute assignment (`obj.files = ...`), which
  `validate_assignment=True` validates on the way in.
- `ApiException` now carries `.data` (typed `ErrorResponse`) alongside
  `.body`; `run()` prefers `.data.to_dict()` and falls back to JSON-parsing
  `.body` when the SDK did not populate `.data`.

### Test harness (`adcc84c`)
- **One pytest run, many SDKs**: `sdk_language` is parametrized via
  `pytest_generate_tests`, so `LANGUAGES=python,node,php ...` walks the
  matrix in a single invocation. `LANGUAGE=<one>` still works. The test run
  fails fast if neither is set so a stray invocation cannot accidentally
  hit every SDK.
- **Readable failures**: `helpers_hsapi._invoke` now always includes exit
  code + stdout + stderr in the `RuntimeError` it raises. Stderr on a
  zero-exit (e.g. Docker's "requested image's platform (linux/amd64) does
  not match the detected host platform" warning on Apple Silicon) is
  ignored when stdout is valid JSON.
- **Graceful 429 handling**: `helpers_hsapi.run` retries HTTP 429 up to
  `SDK_TESTER_RATE_LIMIT_RETRIES` times (default 3), honouring
  `Retry-After` and `X-Ratelimit-Reset` headers, with a default backoff of
  `SDK_TESTER_RATE_LIMIT_BACKOFF` seconds (default 7).
- **Dynamic template discovery**: a new `get_template_id` fixture prefers
  the `TEMPLATE_ID` env var and otherwise picks the first template
  returned by `/v3/template/list`, so we stop chasing the hardcoded IDs
  in `shared_records` when they get deleted from the target env.

### Test / fixture tweaks (`50b162f`)
- `test_create_account_failure`: the API error message wording changed
  ("email_address not valid" → "This value is not a valid email address.").
  Assertion now checks `status_code == 400` and `error_name == 'bad_request'`
  with a loose substring match on the message.
- `signatureRequestCreateEmbedded.json`: `uniqueIdHere_3` had `x=789`,
  outside the page bounds the API now enforces (`0 < x < 680`). Moved to
  `x=400`.
- `test_get_template`: dropped the hardcoded per-server template IDs in
  favour of the new `get_template_id` fixture. Still skips cleanly if
  nothing is reachable or the API returns 404 not_found.

### Docs (`e478ca9`)
Rewritten `README.md` covers prerequisites, the new `./build` options,
environment variables, multi-SDK runs, a troubleshooting section, and
credential hygiene notes.

## Known issues (out of scope)

- **`[dotnet]` `form_field_rules[0].actions[0].type`**: the generated
  `SubFormFieldRuleAction.TypeEnum` has alias members
  (`FieldVisibility = ChangeFieldVisibility`, same for `GroupVisibility`)
  that carry no `[EnumMember]` attribute. Newtonsoft's
  `StringEnumConverter` resolves by integer value and can pick the alias
  name when serializing, producing wire values like `"FieldVisibility"`
  that the API correctly rejects. This is a bug in the upstream
  `dropbox-sign-dotnet` SDK and cannot be fixed in this harness; tracking
  upstream. Three dotnet tests continue to fail on this.