### PR TITLE
[SIGN-15354] Add script to create full set of local sdks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@ Language-agnostic test harness for Dropbox Sign OpenAPI SDKs. Each SDK runs insi
 conftest.py              # pytest fixtures: sdk_runner, get_clientid, etc.
 run                      # bash script that invokes SDK containers via docker
 build                    # bash script to build SDK Docker images
+build-local              # convenience script to build ALL SDKs from local source
 tests/
   test_*.py              # pytest test files — use sdk_runner fixture
   utils/
@@ -58,7 +59,14 @@ python -m pytest tests/ -v --co
 
 # Build with local SDK source for debugging
 ./build --local ../dropbox-sign-python python
+
+# Build ALL SDKs from local source (convenience wrapper)
+./build-local                                    # default: ../openapi/hellosign-openapi/sdks
+./build-local /path/to/sdks                      # custom base path
+./build-local /path/to/sdks v3                   # custom base path + java version suffix
 ```
+
+`build-local` expects SDKs at `<base_path>/<sdk>` and Java at `<base_path>/java-<version>` (default `java-v2`).
 
 Optional env vars: `CLIENT_ID`, `SDK_TESTER_RATE_LIMIT_RETRIES` (default 3), `SDK_TESTER_RATE_LIMIT_BACKOFF` (default 7s).
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ alias for `dotnet`). Examples:
 ./build --sdk-ref=v1.4.0 node        # pin node to a specific upstream ref
 ./build --sdk-ref=2.6.0 java         # pin java to a specific Maven Central release
 ./build --local ../dropbox-sign-python python   # build against a local SDK
+./build-local                        # build ALL SDKs from local source (see below)
 ```
 
 ### Where each SDK comes from
@@ -142,6 +143,20 @@ touched. `--local` does the same plus copies your local SDK into the context
 at `./sdk-src/` and rewrites the descriptor to reference `/sdk-src` inside the
 container (for Java it `mvn install`s the local SDK into the image-local Maven
 repo and pins the tester's `pom.xml` to the version in the local `pom.xml`).
+
+### Building all SDKs from local source with `./build-local`
+
+`./build-local` is a convenience wrapper that builds every SDK from a local
+source tree in one command:
+
+```bash
+./build-local                              # uses default path: ../openapi/hellosign-openapi/sdks
+./build-local /path/to/sdks                # custom base path
+./build-local /path/to/sdks v3             # custom base path + java version suffix
+```
+
+It expects each SDK to live at `<base_path>/<sdk>` (e.g. `../openapi/hellosign-openapi/sdks/python`).
+For Java it appends a version suffix (default `v2`), so the Java SDK is expected at `<base_path>/java-v2`.
 
 For Java, `./build java` with no `--sdk-ref` fetches
 `https://repo1.maven.org/maven2/com/dropbox/sign/dropbox-sign/maven-metadata.xml`

--- a/build-local
+++ b/build-local
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e
+
+BASE_PATH="${1:-../openapi/hellosign-openapi/sdks}"
+JAVA_VERSION="${2:-v2}"
+
+./build --local "$BASE_PATH/dotnet" dotnet
+./build --local "$BASE_PATH/php" php
+./build --local "$BASE_PATH/node" node
+./build --local "$BASE_PATH/ruby" ruby
+./build --local "$BASE_PATH/python" python
+./build --local "$BASE_PATH/java-$JAVA_VERSION" java

--- a/conftest.py
+++ b/conftest.py
@@ -144,7 +144,7 @@ def sdk_runner(container_bin, sdk_language, uploads_dir, auth_type, auth_key, se
 
 @pytest.fixture
 def sdk_retry_runner(container_bin, sdk_language, uploads_dir, auth_type, auth_key, server):
-    def _run(fixture_or_data, placeholders=None, expected_status=200, retries=5, retry_wait=2):
+    def _run(fixture_or_data, placeholders=None, expected_status=200, retries=6, retry_wait=2):
         import time
         json_str = _resolve_json(fixture_or_data, placeholders)
 


### PR DESCRIPTION
  **Summary**
  - Add build-local convenience script that builds all SDK Docker images from a local source tree in one command (defaults to ../openapi/hellosign-openapi/sdks, with configurable base path and Java version suffix)
  - Bump sdk_retry_runner default retries from 5 to 6 for more resilience against eventually-consistent resources
  - Document build-local in README.md and CLAUDE.md

  **Test plan**
  - Run ./build-local with SDKs present at the default path and verify all 6 images build successfully
  - Run ./build-local /custom/path with a custom base path
  - Run ./build-local /custom/path v3 to verify the Java version suffix override
  - Confirm pytest -svra tests/ still passes with the retry change